### PR TITLE
A minimally working version of dbt-duckdb that uses sqlglot for transpiling

### DIFF
--- a/dbt/adapters/duckdb/__version__.py
+++ b/dbt/adapters/duckdb/__version__.py
@@ -1,1 +1,1 @@
-version = "1.2.2"
+version = "1.2.2dev"

--- a/dbt/adapters/duckdb/impl.py
+++ b/dbt/adapters/duckdb/impl.py
@@ -1,3 +1,4 @@
+from dbt.adapters.base.meta import available
 from dbt.adapters.duckdb import DuckDBConnectionManager
 from dbt.adapters.sql import SQLAdapter
 
@@ -12,3 +13,7 @@ class DuckDBAdapter(SQLAdapter):
     @classmethod
     def is_cancelable(cls):
         return False
+
+    @available
+    def transpile(self, sql: str) -> str:
+        return self.connections.transpile(sql)

--- a/dbt/include/duckdb/macros/adapters.sql
+++ b/dbt/include/duckdb/macros/adapters.sql
@@ -36,7 +36,7 @@
   create {% if temporary: -%}temporary{%- endif %} table
     {{ relation.include(database=False, schema=(not temporary)) }}
   as (
-    {{ sql }}
+    {{ adapter.transpile(sql) }}
   );
 
 {% endmacro %}
@@ -46,7 +46,7 @@
 
   {{ sql_header if sql_header is not none }}
   create view {{ relation.include(database=False) }} as (
-    {{ sql }}
+    {{ adapter.transpile(sql) }}
   );
 {% endmacro %}
 


### PR DESCRIPTION
This allows a user to use dbt-duckdb with a dbt project that was written for another database; there is more testing I need to do to verify that this works (e.g. I don't think it handles ephemeral and/or incremental materializations correctly yet.)