### PR TITLE
Override the ADDITIONAL_PROPERTIES setting on the DuckDBCredentials

### DIFF
--- a/dbt/adapters/duckdb/connections.py
+++ b/dbt/adapters/duckdb/connections.py
@@ -54,6 +54,10 @@ class Attachment:
 
 @dataclass
 class DuckDBCredentials(Credentials):
+    # Override this class-level property to prevent typos in the config
+    # options from silently failing during runtime
+    ADDITIONAL_PROPERTIES = False
+
     database: str = "main"
     schema: str = "main"
     path: str = ":memory:"


### PR DESCRIPTION
This will prevent typos in the `Credentials` from causing silent failures at runtime (e.g., because extensions were not actually loaded.)

Gonna solicit some feedback on merging this as there may well be cases I haven't thought of where we _would_ want arbitrary properties to be added to the profile, but I'm not sure of what they would be just yet.