### PR TITLE
Add a more helpful error message in the case that the options argument isn't a dictionary

### DIFF
--- a/dbt/include/duckdb/macros/adapters.sql
+++ b/dbt/include/duckdb/macros/adapters.sql
@@ -202,6 +202,10 @@ def materialize(df, con):
 
 {% macro render_write_options(config) -%}
   {% set options = config.get('options', {}) %}
+  {% if options is not mapping %}
+    {% do exceptions.raise_compiler_error("The options argument must be a dictionary") %}
+  {% endif %}
+
   {% for k in options %}
     {% if options[k] is string %}
       {% set _ = options.update({k: render(options[k])}) %}


### PR DESCRIPTION
A couple of different folks have hit hard-to-diagnose errors when they pass in a string for the `options` field in external materializations; since I need to be able to use the `partition_by` field in order to correctly create a view for the materialized file(s), I need to keep the `options` field as a dictionary and provide a more helpful error message in the situation that another variable type (e.g., a string) is passed instead.