### PR TITLE
Refactor render_write_options for direct option rendering

### DIFF
--- a/dbt/include/duckdb/macros/adapters.sql
+++ b/dbt/include/duckdb/macros/adapters.sql
@@ -207,11 +207,7 @@ def materialize(df, con):
   {% endif %}
 
   {% for k in options %}
-    {% if options[k] is string %}
-      {% set _ = options.update({k: render(options[k])}) %}
-    {% else %}
-      {% set _ = options.update({k: render(options[k])}) %}
-    {% endif %}
+    {% set _ = options.update({k: render(options[k])}) %}
   {% endfor %}
 
   {# legacy top-level write options #}


### PR DESCRIPTION
Removed an unnecessary if-else condition in the render_write_options macro, eliminating the need for type checking.