### PR TITLE
Add a sample_profiles.yml file for dbt-duckdb

### DIFF
--- a/dbt/include/duckdb/sample_profiles.yml
+++ b/dbt/include/duckdb/sample_profiles.yml
@@ -1,0 +1,11 @@
+default:
+  outputs:
+    dev:
+      type: duckdb
+      path: dev.duckdb
+
+    prod:
+      type: duckdb
+      path: prod.duckdb
+
+  target: dev

--- a/dbt/include/duckdb/sample_profiles.yml
+++ b/dbt/include/duckdb/sample_profiles.yml
@@ -3,9 +3,11 @@ default:
     dev:
       type: duckdb
       path: dev.duckdb
+      threads: 1
 
     prod:
       type: duckdb
       path: prod.duckdb
+      threads: 4
 
   target: dev


### PR DESCRIPTION
so as to make an initial `dbt init` operation even more seamless from the user's perspective.