### PR TITLE
Enable batch processing on Python models

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,27 @@ object that can be easily converted into a Pandas/Polars DataFrame or an Arrow t
 any Python object that DuckDB knows how to turn into a table, including a Pandas/Polars `DataFrame`, a DuckDB `Relation`, or an Arrow `Table`,
 `Dataset`, `RecordBatchReader`, or `Scanner`.
 
+#### Batch processing with Python models
+
+As of version 1.7.0, it is possible to both read and write data in chunks, which allows for larger-than-memory
+datasets to be manipulated in Python models. Here is a basic example:
+```
+import pyarrow as pa
+
+def batcher(batch_reader: pa.RecordBatchReader):
+    for batch in batch_reader:
+        df = batch.to_pandas()
+        # Do some operations on the DF...
+        # ...then yield back a new batch
+        yield pa.RecordBatch.from_pandas(df)
+
+def model(dbt, session):
+    big_model = dbt.ref("big_model")
+    batch_reader = big_model.record_batch(100_000)
+    batch_iter = batcher(batch_reader)
+    return pa.RecordBatchReader.from_batches(batch_reader.schema, batch_iter)
+```
+
 ### Writing Your Own Plugins
 
 Defining your own dbt-duckdb plugin is as simple as creating a python module that defines a class named `Plugin` that

--- a/dbt/adapters/duckdb/environments/__init__.py
+++ b/dbt/adapters/duckdb/environments/__init__.py
@@ -148,9 +148,11 @@ class Environment(abc.ABC):
                     "Python module spec is missing loader: {}".format(identifier)
                 )
 
+            # Create a separate read cursor to enable batched reads/writes
+            cur = con.cursor()
             # Do the actual work to run the code here
             dbt = module.dbtObj(load_df_function)
-            df = module.model(dbt, con)
+            df = module.model(dbt, cur)
             module.materialize(df, con)
         except Exception as err:
             raise DbtRuntimeError(f"Python model failed:\n" f"{err}")

--- a/dbt/adapters/duckdb/environments/__init__.py
+++ b/dbt/adapters/duckdb/environments/__init__.py
@@ -125,7 +125,9 @@ class Environment(abc.ABC):
         return ret
 
     @classmethod
-    def run_python_job(cls, con, load_df_function, identifier: str, compiled_code: str):
+    def run_python_job(
+        cls, con, load_df_function, identifier: str, compiled_code: str, creds: DuckDBCredentials
+    ):
         mod_file = tempfile.NamedTemporaryFile(suffix=".py", delete=False)
         mod_file.write(compiled_code.lstrip().encode("utf-8"))
         mod_file.close()
@@ -149,7 +151,7 @@ class Environment(abc.ABC):
                 )
 
             # Create a separate read cursor to enable batched reads/writes
-            cur = self.initialize_cursor(self.creds, con.cursor())
+            cur = cls.initialize_cursor(creds, con.cursor())
             # Do the actual work to run the code here
             dbt = module.dbtObj(load_df_function)
             df = module.model(dbt, cur)

--- a/dbt/adapters/duckdb/environments/__init__.py
+++ b/dbt/adapters/duckdb/environments/__init__.py
@@ -149,7 +149,7 @@ class Environment(abc.ABC):
                 )
 
             # Create a separate read cursor to enable batched reads/writes
-            cur = con.cursor()
+            cur = self.initialize_cursor(self.creds, con.cursor())
             # Do the actual work to run the code here
             dbt = module.dbtObj(load_df_function)
             df = module.model(dbt, cur)

--- a/dbt/adapters/duckdb/environments/local.py
+++ b/dbt/adapters/duckdb/environments/local.py
@@ -75,7 +75,7 @@ class LocalEnvironment(Environment):
         def ldf(table_name):
             return con.query(f"select * from {table_name}")
 
-        self.run_python_job(con, ldf, parsed_model["alias"], compiled_code)
+        self.run_python_job(con, ldf, parsed_model["alias"], compiled_code, self.creds)
         return AdapterResponse(_message="OK")
 
     def load_source(self, plugin_name: str, source_config: utils.SourceConfig):


### PR DESCRIPTION
Creates a separate cursor for the `dbt` object in a Python model, which prevents deadlocks when trying to read and write at the same time.