### PR TITLE
Fix cursor isolation on Python model

### DIFF
--- a/dbt/adapters/duckdb/environments/__init__.py
+++ b/dbt/adapters/duckdb/environments/__init__.py
@@ -154,8 +154,8 @@ class Environment(abc.ABC):
             cur = cls.initialize_cursor(creds, con.cursor())
             # Do the actual work to run the code here
             dbt = module.dbtObj(load_df_function)
-            df = module.model(dbt, cur)
-            module.materialize(df, con)
+            df = module.model(dbt, con)
+            module.materialize(df, cur)
         except Exception as err:
             raise DbtRuntimeError(f"Python model failed:\n" f"{err}")
         finally:


### PR DESCRIPTION
The read cursor is controlled by a separate function - changing so that the new cursor is applied to `materialize` instead.