### PR TITLE
Re-enable returning a temp table in python models

### DIFF
--- a/tests/functional/adapter/test_python_model.py
+++ b/tests/functional/adapter/test_python_model.py
@@ -103,6 +103,30 @@ class TestEmptyPythonModel:
         )
         assert result == [("a", "VARCHAR"), ("b", "BOOLEAN")]
 
+temp_upstream_model_python = """
+def model(dbt, con):
+    dbt.config(
+        materialized='table',
+    )
+    con.execute("create temp table t(a int)")
+    return con.table("t")
+"""
+
+
+class TestTempTablePythonModel:
+    """
+    This test ensures that Python models returning a DuckDBPyRelation based
+    on a temporary duckdb table can still be materialized
+    """
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "upstream_model.py": temp_upstream_model_python,
+        }
+    
+    def test_run(self, project):
+        run_dbt(["run"])
 
 python_pyarrow_table_model = """
 import pyarrow as pa


### PR DESCRIPTION
The following sequence of MRs added cursor isolation when writing back to Duckdb:
- https://github.com/duckdb/dbt-duckdb/pull/269
- https://github.com/duckdb/dbt-duckdb/pull/270

This has the consequence that any dbt python model that returns a DuckDbPyRelation referring to a temporary table will fail, since temp tables do not cross cursor boundaries.

We add a special code path to re-enable this case.