### PR TITLE
Add support for providing additional kwargs for sqlalchemy connection

### DIFF
--- a/dbt/adapters/duckdb/plugins/sqlalchemy.py
+++ b/dbt/adapters/duckdb/plugins/sqlalchemy.py
@@ -13,7 +13,8 @@ from ..utils import TargetConfig
 
 class Plugin(BasePlugin):
     def initialize(self, plugin_config: Dict[str, Any]):
-        self.engine = create_engine(plugin_config["connection_url"])
+        self.engine = create_engine(plugin_config.pop("connection_url"), 
+                                    **plugin_config)
 
     def load(self, source_config: SourceConfig) -> pd.DataFrame:
         if "query" in source_config:

--- a/dbt/adapters/duckdb/plugins/sqlalchemy.py
+++ b/dbt/adapters/duckdb/plugins/sqlalchemy.py
@@ -13,8 +13,7 @@ from ..utils import TargetConfig
 
 class Plugin(BasePlugin):
     def initialize(self, plugin_config: Dict[str, Any]):
-        self.engine = create_engine(plugin_config.pop("connection_url"), 
-            **plugin_config)
+        self.engine = create_engine(plugin_config.pop("connection_url"), **plugin_config)
 
     def load(self, source_config: SourceConfig) -> pd.DataFrame:
         if "query" in source_config:

--- a/dbt/adapters/duckdb/plugins/sqlalchemy.py
+++ b/dbt/adapters/duckdb/plugins/sqlalchemy.py
@@ -14,7 +14,7 @@ from ..utils import TargetConfig
 class Plugin(BasePlugin):
     def initialize(self, plugin_config: Dict[str, Any]):
         self.engine = create_engine(plugin_config.pop("connection_url"), 
-                                    **plugin_config)
+            **plugin_config)
 
     def load(self, source_config: SourceConfig) -> pd.DataFrame:
         if "query" in source_config:


### PR DESCRIPTION
Additional keyword arguments may vary across dialects, and some connections may not work without specific keyword arguments.

Additional keyword arguments can now be added at the same level as the connection_url.

Example:
```
default:
  outputs:
    dev:
      type: duckdb
      path: /tmp/dbt.duckdb
      plugins:
        - module: gsheet
          config:
            method: oauth
        - module: sqlalchemy
          alias: myoracledb
          config:
            connection_url: "{{ env_var('DBT_ENV_SECRET_SQLALCHEMY_URI') }}"
            thick_mode: true
        - module: path.to.custom_udf_module
```