### PR TITLE
Provide support for Postgres-specific ATTACH options

### DIFF
--- a/dbt/adapters/duckdb/credentials.py
+++ b/dbt/adapters/duckdb/credentials.py
@@ -16,8 +16,12 @@ from dbt.dataclass_schema import dbtClassMixin
 
 @dataclass
 class Attachment(dbtClassMixin):
-    # The path to the database to be attached (may be a URL)
+    # The path to the database to be attached (may be a URL or Postgres dsn)
     path: str
+
+    # Any other options for the attachment path (e.g., the Postgres attachment type has
+    # source_schema, sink_schema, and overwrite options)
+    options: Optional[Dict[str, Any]] = None
 
     # The type of the attached database (defaults to duckdb, but may be supported by an extension)
     type: Optional[str] = None
@@ -29,16 +33,21 @@ class Attachment(dbtClassMixin):
     read_only: bool = False
 
     def to_sql(self) -> str:
-        base = f"ATTACH '{self.path}'"
+        if self.options:
+            opts = ", ".join([f"{key} = '{value}'" for key, value in self.options.items()])
+            base = f"ATTACH ('{self.path}', {opts})"
+        else:
+            base = f"ATTACH '{self.path}'"
         if self.alias:
             base += f" AS {self.alias}"
-        options = []
+
+        type_options = []
         if self.type:
-            options.append(f"TYPE {self.type}")
+            type_options.append(f"TYPE {self.type}")
         if self.read_only:
-            options.append("READ_ONLY")
-        if options:
-            joined = ", ".join(options)
+            type_options.append("READ_ONLY")
+        if type_options:
+            joined = ", ".join(type_options)
             base += f" ({joined})"
         return base
 

--- a/tests/unit/test_connections.py
+++ b/tests/unit/test_connections.py
@@ -40,12 +40,15 @@ def test_load_aws_creds(mock_session_class):
 
 def test_attachments():
     creds = DuckDBCredentials()
+    opts = {"source_schema": "public", "sink_schema": "snk"}
     creds.attach = [
         {"path": "/tmp/f1234.db"},
         {"path": "/tmp/g1234.db", "alias": "g"},
         {"path": "/tmp/h5678.db", "read_only": 1},
         {"path": "/tmp/i9101.db", "type": "sqlite"},
         {"path": "/tmp/jklm.db", "alias": "jk", "read_only": 1, "type": "sqlite"},
+        {"path": "dbname=prod host=127.0.0.1 user=postgres", "type": "postgres"},
+        {"path": "dbname=postgres", "options": opts, "alias": "pg"}
     ]
 
     expected_sql = [
@@ -54,6 +57,8 @@ def test_attachments():
         "ATTACH '/tmp/h5678.db' (READ_ONLY)",
         "ATTACH '/tmp/i9101.db' (TYPE sqlite)",
         "ATTACH '/tmp/jklm.db' AS jk (TYPE sqlite, READ_ONLY)",
+        "ATTACH 'dbname=prod host=127.0.0.1 user=postgres' (TYPE postgres)",
+        "ATTACH ('dbname=postgres', source_schema = 'public', sink_schema = 'snk') AS pg"
     ]
 
     for i, a in enumerate(creds.attach):


### PR DESCRIPTION
Documented here: https://duckdb.org/docs/extensions/postgres

There are some settings you can put on the `ATTACH` statement that do not exist for other types of attachable databases; adding support for them here on the theory that this sort of thing will come up more often soon (e.g., for Iceberg catalogs.)