### PR TITLE
Revert "Provide support for Postgres-specific ATTACH options"

### DIFF
--- a/dbt/adapters/duckdb/credentials.py
+++ b/dbt/adapters/duckdb/credentials.py
@@ -16,12 +16,8 @@ from dbt.dataclass_schema import dbtClassMixin
 
 @dataclass
 class Attachment(dbtClassMixin):
-    # The path to the database to be attached (may be a URL or Postgres dsn)
+    # The path to the database to be attached (may be a URL)
     path: str
-
-    # Any other options for the attachment path (e.g., the Postgres attachment type has
-    # source_schema, sink_schema, and overwrite options)
-    options: Optional[Dict[str, Any]] = None
 
     # The type of the attached database (defaults to duckdb, but may be supported by an extension)
     type: Optional[str] = None
@@ -33,21 +29,16 @@ class Attachment(dbtClassMixin):
     read_only: bool = False
 
     def to_sql(self) -> str:
-        if self.options:
-            opts = ", ".join([f"{key} = '{value}'" for key, value in self.options.items()])
-            base = f"ATTACH ('{self.path}', {opts})"
-        else:
-            base = f"ATTACH '{self.path}'"
+        base = f"ATTACH '{self.path}'"
         if self.alias:
             base += f" AS {self.alias}"
-
-        type_options = []
+        options = []
         if self.type:
-            type_options.append(f"TYPE {self.type}")
+            options.append(f"TYPE {self.type}")
         if self.read_only:
-            type_options.append("READ_ONLY")
-        if type_options:
-            joined = ", ".join(type_options)
+            options.append("READ_ONLY")
+        if options:
+            joined = ", ".join(options)
             base += f" ({joined})"
         return base
 

--- a/tests/unit/test_connections.py
+++ b/tests/unit/test_connections.py
@@ -40,15 +40,12 @@ def test_load_aws_creds(mock_session_class):
 
 def test_attachments():
     creds = DuckDBCredentials()
-    opts = {"source_schema": "public", "sink_schema": "snk"}
     creds.attach = [
         {"path": "/tmp/f1234.db"},
         {"path": "/tmp/g1234.db", "alias": "g"},
         {"path": "/tmp/h5678.db", "read_only": 1},
         {"path": "/tmp/i9101.db", "type": "sqlite"},
         {"path": "/tmp/jklm.db", "alias": "jk", "read_only": 1, "type": "sqlite"},
-        {"path": "dbname=prod host=127.0.0.1 user=postgres", "type": "postgres"},
-        {"path": "dbname=postgres", "options": opts, "alias": "pg"}
     ]
 
     expected_sql = [
@@ -57,8 +54,6 @@ def test_attachments():
         "ATTACH '/tmp/h5678.db' (READ_ONLY)",
         "ATTACH '/tmp/i9101.db' (TYPE sqlite)",
         "ATTACH '/tmp/jklm.db' AS jk (TYPE sqlite, READ_ONLY)",
-        "ATTACH 'dbname=prod host=127.0.0.1 user=postgres' (TYPE postgres)",
-        "ATTACH ('dbname=postgres', source_schema = 'public', sink_schema = 'snk') AS pg"
     ]
 
     for i, a in enumerate(creds.attach):


### PR DESCRIPTION
Reverts duckdb/dbt-duckdb#309 -- turned out there was a bug in the docs and this syntax isn't going to be supported, at least not in this way. The existing config options in place are right/good for supporting postgres attachments.