### PR TITLE
Add custom_user_agent to connection config when connecting to MotherDuck

### DIFF
--- a/dbt/adapters/duckdb/environments/__init__.py
+++ b/dbt/adapters/duckdb/environments/__init__.py
@@ -119,7 +119,7 @@ class Environment(abc.ABC):
             user_agent = f"dbt/{__version__}"
             if "custom_user_agent" in config:
                 user_agent = f"{user_agent} {config['custom_user_agent']}"
-                
+
             config["custom_user_agent"] = user_agent
 
         if creds.retries:

--- a/dbt/adapters/duckdb/environments/__init__.py
+++ b/dbt/adapters/duckdb/environments/__init__.py
@@ -16,6 +16,7 @@ from ..utils import SourceConfig
 from ..utils import TargetConfig
 from dbt.contracts.connection import AdapterResponse
 from dbt.exceptions import DbtRuntimeError
+from dbt.version import __version__
 
 
 def _ensure_event_loop():
@@ -114,6 +115,12 @@ class Environment(abc.ABC):
         cls, creds: DuckDBCredentials, plugins: Optional[Dict[str, BasePlugin]] = None
     ):
         config = creds.config_options or {}
+        if creds.is_motherduck:
+            user_agent = f"dbt/{__version__}"
+            if "custom_user_agent" in config:
+                user_agent = f"{user_agent} {config['custom_user_agent']}"
+                
+            config["custom_user_agent"] = user_agent
 
         if creds.retries:
             success, attempt, exc = False, 0, None

--- a/tests/functional/plugins/test_motherduck.py
+++ b/tests/functional/plugins/test_motherduck.py
@@ -5,6 +5,7 @@ from dbt.tests.util import (
 )
 from dbt.adapters.duckdb.environments import Environment
 from dbt.adapters.duckdb.credentials import DuckDBCredentials
+from dbt.version import __version__
 
 random_logs_sql = """
 {{ config(materialized='table', meta=dict(temp_schema_name='dbt_temp_test')) }}
@@ -37,10 +38,6 @@ from {{ ref('random_logs_test') }}
 {% endif %}
 group by all
 """
-
-@pytest.fixture
-def test_path():
-    return "md:test"
 
 @pytest.mark.skip_profile("buenavista", "file", "memory")
 class TestMDPlugin:
@@ -108,10 +105,11 @@ class TestMDPlugin:
         res = project.run_sql("SELECT schema_name FROM information_schema.schemata WHERE catalog_name = 'test'", fetch="all")
         assert "dbt_temp_test" in [_r for (_r,) in res]
 
-def test_motherduck_user_agent(test_path):
+def test_motherduck_user_agent(dbt_profile_target):
+    test_path = dbt_profile_target["path"]
     kwargs = {
         'read_only': False,
-        'config': {'custom_user_agent': 'dbt/1.7.6'}
+        'config': {'custom_user_agent': f'dbt/{__version__}'}
     }
     creds = DuckDBCredentials(path=test_path)
     with mock.patch("dbt.adapters.duckdb.environments.duckdb.connect") as mock_connect:

--- a/tests/functional/plugins/test_motherduck.py
+++ b/tests/functional/plugins/test_motherduck.py
@@ -114,12 +114,7 @@ def test_motherduck_user_agent(dbt_profile_target):
     creds = DuckDBCredentials(path=test_path)
     with mock.patch("dbt.adapters.duckdb.environments.duckdb.connect") as mock_connect:
         Environment.initialize_db(creds)
-        mock_connect.assert_called_with(test_path, **kwargs)
-
-
-def test_no_motherduck_user_agent(dbt_profile_target):
-    test_path = ":memory:"
-    creds = DuckDBCredentials(path=test_path)
-    with mock.patch("dbt.adapters.duckdb.environments.duckdb.connect") as mock_connect:
-        Environment.initialize_db(creds)
-        mock_connect.assert_called_with(test_path, read_only=False, config = {})
+        if creds.is_motherduck:
+            mock_connect.assert_called_with(test_path, **kwargs)
+        else:
+            mock_connect.assert_called_with(test_path, read_only=False, config = {})

--- a/tests/functional/plugins/test_motherduck.py
+++ b/tests/functional/plugins/test_motherduck.py
@@ -107,14 +107,14 @@ class TestMDPlugin:
 
 def test_motherduck_user_agent(dbt_profile_target):
     test_path = dbt_profile_target["path"]
-    kwargs = {
-        'read_only': False,
-        'config': {'custom_user_agent': f'dbt/{__version__}'}
-    }
     creds = DuckDBCredentials(path=test_path)
     with mock.patch("dbt.adapters.duckdb.environments.duckdb.connect") as mock_connect:
         Environment.initialize_db(creds)
         if creds.is_motherduck:
+            kwargs = {
+                'read_only': False,
+                'config': {'custom_user_agent': f'dbt/{__version__}'}
+            }
             mock_connect.assert_called_with(test_path, **kwargs)
         else:
             mock_connect.assert_called_with(test_path, read_only=False, config = {})

--- a/tests/functional/plugins/test_motherduck.py
+++ b/tests/functional/plugins/test_motherduck.py
@@ -115,3 +115,11 @@ def test_motherduck_user_agent(dbt_profile_target):
     with mock.patch("dbt.adapters.duckdb.environments.duckdb.connect") as mock_connect:
         Environment.initialize_db(creds)
         mock_connect.assert_called_with(test_path, **kwargs)
+
+
+def test_no_motherduck_user_agent(dbt_profile_target):
+    test_path = ":memory:"
+    creds = DuckDBCredentials(path=test_path)
+    with mock.patch("dbt.adapters.duckdb.environments.duckdb.connect") as mock_connect:
+        Environment.initialize_db(creds)
+        mock_connect.assert_called_with(test_path, read_only=False, config = {})


### PR DESCRIPTION
This adds a `custom_user_agent` key to the config passed to `duckdb.connect`. For more details see [docs](https://motherduck.com/docs/integrations/how-to-integrate/#python).