### PR TITLE
Fix: MotherDuck token from plugin config should override env var

### DIFF
--- a/dbt/adapters/duckdb/credentials.py
+++ b/dbt/adapters/duckdb/credentials.py
@@ -165,7 +165,7 @@ class DuckDBCredentials(Credentials):
         """
         plugins = self.plugins or []
         for plugin in plugins:
-            if plugin.module == "motherduck" and plugin.config:
+            if plugin.config:
                 token = plugin.config.get("token") or ""
                 return str(token)
         return ""

--- a/dbt/adapters/duckdb/credentials.py
+++ b/dbt/adapters/duckdb/credentials.py
@@ -154,7 +154,7 @@ class DuckDBCredentials(Credentials):
     @staticmethod
     def _is_motherduck(scheme: str) -> bool:
         return scheme in {"md", "motherduck"}
-    
+
     @property
     def motherduck_token(self) -> str:
         plugins = self.plugins or []

--- a/dbt/adapters/duckdb/credentials.py
+++ b/dbt/adapters/duckdb/credentials.py
@@ -156,11 +156,12 @@ class DuckDBCredentials(Credentials):
         return scheme in {"md", "motherduck"}
 
     @property
-    def motherduck_token(self) -> str:
+    def motherduck_token(self) -> Optional[str]:
         plugins = self.plugins or []
         for plugin in plugins:
-            if plugin.module == "motherduck":
-                return plugin.config.get("token")
+            if plugin.module == "motherduck" and plugin.config:
+                token = plugin.config.get("token") or ""
+                return str(token)
 
     @classmethod
     def __pre_deserialize__(cls, data: Dict[Any, Any]) -> Dict[Any, Any]:

--- a/dbt/adapters/duckdb/credentials.py
+++ b/dbt/adapters/duckdb/credentials.py
@@ -155,21 +155,6 @@ class DuckDBCredentials(Credentials):
     def _is_motherduck(scheme: str) -> bool:
         return scheme in {"md", "motherduck"}
 
-    @property
-    def token_from_config(self) -> str:
-        """Load the token from the MotherDuck plugin config
-        If not specified, this returns an empty string
-
-        Returns:
-            str: MotherDuck token
-        """
-        plugins = self.plugins or []
-        for plugin in plugins:
-            if plugin.config:
-                token = plugin.config.get("token") or ""
-                return str(token)
-        return ""
-
     @classmethod
     def __pre_deserialize__(cls, data: Dict[Any, Any]) -> Dict[Any, Any]:
         data = super().__pre_deserialize__(data)

--- a/dbt/adapters/duckdb/credentials.py
+++ b/dbt/adapters/duckdb/credentials.py
@@ -156,12 +156,13 @@ class DuckDBCredentials(Credentials):
         return scheme in {"md", "motherduck"}
 
     @property
-    def motherduck_token(self) -> Optional[str]:
+    def motherduck_token(self) -> str:
         plugins = self.plugins or []
         for plugin in plugins:
             if plugin.module == "motherduck" and plugin.config:
                 token = plugin.config.get("token") or ""
                 return str(token)
+        return ""
 
     @classmethod
     def __pre_deserialize__(cls, data: Dict[Any, Any]) -> Dict[Any, Any]:

--- a/dbt/adapters/duckdb/credentials.py
+++ b/dbt/adapters/duckdb/credentials.py
@@ -156,7 +156,13 @@ class DuckDBCredentials(Credentials):
         return scheme in {"md", "motherduck"}
 
     @property
-    def motherduck_token(self) -> str:
+    def token_from_config(self) -> str:
+        """Load the token from the MotherDuck plugin config
+        If not specified, this returns an empty string
+
+        Returns:
+            str: MotherDuck token
+        """
         plugins = self.plugins or []
         for plugin in plugins:
             if plugin.module == "motherduck" and plugin.config:

--- a/dbt/adapters/duckdb/credentials.py
+++ b/dbt/adapters/duckdb/credentials.py
@@ -154,6 +154,13 @@ class DuckDBCredentials(Credentials):
     @staticmethod
     def _is_motherduck(scheme: str) -> bool:
         return scheme in {"md", "motherduck"}
+    
+    @property
+    def motherduck_token(self) -> str:
+        plugins = self.plugins or []
+        for plugin in plugins:
+            if plugin.module == "motherduck":
+                return plugin.config.get("token")
 
     @classmethod
     def __pre_deserialize__(cls, data: Dict[Any, Any]) -> Dict[Any, Any]:

--- a/dbt/adapters/duckdb/environments/__init__.py
+++ b/dbt/adapters/duckdb/environments/__init__.py
@@ -122,6 +122,9 @@ class Environment(abc.ABC):
 
             config["custom_user_agent"] = user_agent
 
+            if creds.motherduck_token:
+                config["motherduck_token"] = creds.motherduck_token
+
         if creds.retries:
             success, attempt, exc = False, 0, None
             while not success and attempt < creds.retries.connect_attempts:

--- a/dbt/adapters/duckdb/environments/__init__.py
+++ b/dbt/adapters/duckdb/environments/__init__.py
@@ -122,8 +122,10 @@ class Environment(abc.ABC):
 
             config["custom_user_agent"] = user_agent
 
-            if creds.motherduck_token != "":
-                config["motherduck_token"] = creds.motherduck_token
+            # If a user specified the token via the plugin config,
+            # pass it to the config kwarg in duckdb.connect
+            if creds.token_from_config != "":
+                config["motherduck_token"] = creds.token_from_config
 
         if creds.retries:
             success, attempt, exc = False, 0, None

--- a/dbt/adapters/duckdb/environments/__init__.py
+++ b/dbt/adapters/duckdb/environments/__init__.py
@@ -122,7 +122,7 @@ class Environment(abc.ABC):
 
             config["custom_user_agent"] = user_agent
 
-            if creds.motherduck_token:
+            if creds.motherduck_token != "":
                 config["motherduck_token"] = creds.motherduck_token
 
         if creds.retries:

--- a/dbt/adapters/duckdb/environments/__init__.py
+++ b/dbt/adapters/duckdb/environments/__init__.py
@@ -16,7 +16,6 @@ from ..utils import SourceConfig
 from ..utils import TargetConfig
 from dbt.contracts.connection import AdapterResponse
 from dbt.exceptions import DbtRuntimeError
-from dbt.version import __version__
 
 
 def _ensure_event_loop():
@@ -115,17 +114,9 @@ class Environment(abc.ABC):
         cls, creds: DuckDBCredentials, plugins: Optional[Dict[str, BasePlugin]] = None
     ):
         config = creds.config_options or {}
-        if creds.is_motherduck:
-            user_agent = f"dbt/{__version__}"
-            if "custom_user_agent" in config:
-                user_agent = f"{user_agent} {config['custom_user_agent']}"
-
-            config["custom_user_agent"] = user_agent
-
-            # If a user specified the token via the plugin config,
-            # pass it to the config kwarg in duckdb.connect
-            if creds.token_from_config != "":
-                config["motherduck_token"] = creds.token_from_config
+        plugins = plugins or {}
+        for plugin in plugins.values():
+            plugin.update_connection_config(creds, config)
 
         if creds.retries:
             success, attempt, exc = False, 0, None

--- a/dbt/adapters/duckdb/plugins/__init__.py
+++ b/dbt/adapters/duckdb/plugins/__init__.py
@@ -92,6 +92,8 @@ class BasePlugin:
     def update_connection_config(self, creds: DuckDBCredentials, config: Dict[str, Any]):
         """
         This updates the DuckDB connection config if needed.
+        This method should be overridden by subclasses to add any additional
+        config options needed on the connection, such as a connection token or user agent
 
         :param creds: DuckDB credentials
         :param config: Config dictionary to be passed to duckdb.connect

--- a/dbt/adapters/duckdb/plugins/__init__.py
+++ b/dbt/adapters/duckdb/plugins/__init__.py
@@ -89,7 +89,7 @@ class BasePlugin:
         """
         pass
 
-    def update_connection_config(self, creds: DuckDBCredentials, config: dict[str, Any]):
+    def update_connection_config(self, creds: DuckDBCredentials, config: Dict[str, Any]):
         """
         This updates the DuckDB connection config if needed.
 

--- a/dbt/adapters/duckdb/plugins/__init__.py
+++ b/dbt/adapters/duckdb/plugins/__init__.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 from duckdb import DuckDBPyConnection
 
+from ..credentials import DuckDBCredentials
 from ..utils import SourceConfig
 from ..utils import TargetConfig
 from dbt.dataclass_schema import dbtClassMixin
@@ -85,6 +86,15 @@ class BasePlugin:
         additional initialization steps.
 
         :param plugin_config: A dictionary representing the plugin configuration.
+        """
+        pass
+
+    def update_connection_config(self, creds: DuckDBCredentials, config: dict[str, Any]):
+        """
+        This updates the DuckDB connection config if needed.
+
+        :param creds: DuckDB credentials
+        :param config: Config dictionary to be passed to duckdb.connect
         """
         pass
 

--- a/dbt/adapters/duckdb/plugins/motherduck.py
+++ b/dbt/adapters/duckdb/plugins/motherduck.py
@@ -12,6 +12,3 @@ class Plugin(BasePlugin):
 
     def configure_connection(self, conn: DuckDBPyConnection):
         conn.load_extension("motherduck")
-        if self._token:
-            connect_stmt = f"SET motherduck_token={self._token}')"
-            conn.execute(connect_stmt)

--- a/dbt/adapters/duckdb/plugins/motherduck.py
+++ b/dbt/adapters/duckdb/plugins/motherduck.py
@@ -4,6 +4,8 @@ from typing import Dict
 from duckdb import DuckDBPyConnection
 
 from . import BasePlugin
+from dbt.adapters.duckdb.credentials import DuckDBCredentials
+from dbt.version import __version__
 
 
 class Plugin(BasePlugin):
@@ -12,3 +14,15 @@ class Plugin(BasePlugin):
 
     def configure_connection(self, conn: DuckDBPyConnection):
         conn.load_extension("motherduck")
+
+    def update_connection_config(self, creds: DuckDBCredentials, config: dict[str, Any]):
+        user_agent = f"dbt/{__version__}"
+        if "custom_user_agent" in config:
+            user_agent = f"{user_agent} {config['custom_user_agent']}"
+
+        config["custom_user_agent"] = user_agent
+
+        # If a user specified the token via the plugin config,
+        # pass it to the config kwarg in duckdb.connect
+        if creds.token_from_config != "":
+            config["motherduck_token"] = creds.token_from_config

--- a/dbt/adapters/duckdb/plugins/motherduck.py
+++ b/dbt/adapters/duckdb/plugins/motherduck.py
@@ -15,7 +15,7 @@ class Plugin(BasePlugin):
     def configure_connection(self, conn: DuckDBPyConnection):
         conn.load_extension("motherduck")
 
-    def update_connection_config(self, creds: DuckDBCredentials, config: dict[str, Any]):
+    def update_connection_config(self, creds: DuckDBCredentials, config: Dict[str, Any]):
         user_agent = f"dbt/{__version__}"
         if "custom_user_agent" in config:
             user_agent = f"{user_agent} {config['custom_user_agent']}"

--- a/dbt/adapters/duckdb/plugins/motherduck.py
+++ b/dbt/adapters/duckdb/plugins/motherduck.py
@@ -15,6 +15,20 @@ class Plugin(BasePlugin):
     def configure_connection(self, conn: DuckDBPyConnection):
         conn.load_extension("motherduck")
 
+    @staticmethod
+    def token_from_config(creds: DuckDBCredentials) -> str:
+        """Load the token from the MotherDuck plugin config
+        If not specified, this returns an empty string
+
+        :param str: MotherDuck token
+        """
+        plugins = creds.plugins or []
+        for plugin in plugins:
+            if plugin.config:
+                token = plugin.config.get("token") or ""
+                return str(token)
+        return ""
+
     def update_connection_config(self, creds: DuckDBCredentials, config: Dict[str, Any]):
         user_agent = f"dbt/{__version__}"
         if "custom_user_agent" in config:
@@ -24,5 +38,6 @@ class Plugin(BasePlugin):
 
         # If a user specified the token via the plugin config,
         # pass it to the config kwarg in duckdb.connect
-        if creds.token_from_config != "":
-            config["motherduck_token"] = creds.token_from_config
+        token = self.token_from_config(creds)
+        if token != "":
+            config["motherduck_token"] = token

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "dbt-core~=1.7.0",
-        "duckdb>=0.7.0",
+        "duckdb>=0.7.0,<=0.9.2",
     ],
     extras_require={
         "glue": ["boto3", "mypy-boto3-glue"],

--- a/setup.py
+++ b/setup.py
@@ -38,11 +38,9 @@ setup(
     include_package_data=True,
     install_requires=[
         "dbt-core~=1.7.0",
-        "duckdb>=0.7.0,<=0.9.2",
+        "duckdb>=0.7.0",
     ],
-    extras_require={
-        "glue": ["boto3", "mypy-boto3-glue"],
-    },
+    extras_require={"glue": ["boto3", "mypy-boto3-glue"], "md": ["duckdb>=0.7.0,<=0.9.2"]},
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: Apache Software License",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,9 +65,12 @@ def dbt_profile_target(profile_type, bv_server_process, tmp_path_factory):
     elif profile_type == "md":
         # Test against MotherDuck
         if "MOTHERDUCK_TOKEN" not in os.environ:
-            raise ValueError(
-                "Please set the MOTHERDUCK_TOKEN environment variable to run tests against MotherDuck"
-            )
+            if "TEST_MOTHERDUCK_TOKEN" not in os.environ:
+                raise ValueError(
+                    "Please set the MOTHERDUCK_TOKEN or TEST_MOTHERDUCK_TOKEN \
+                        environment variable to run tests against MotherDuck"
+                )
+            profile["token"] = os.environ.get("TEST_MOTHERDUCK_TOKEN")
         profile["disable_transactions"] = True
         profile["path"] = "md:test"
     elif profile_type == "memory":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,7 +67,7 @@ def dbt_profile_target(profile_type, bv_server_process, tmp_path_factory):
         profile["path"] = str(tmp_path_factory.getbasetemp() / "tmp.db")
     elif profile_type == "md":
         # Test against MotherDuck
-        if MOTHERDUCK_TOKEN not in os.environ or MOTHERDUCK_TOKEN.lower() not in os.environ:
+        if MOTHERDUCK_TOKEN not in os.environ and MOTHERDUCK_TOKEN.lower() not in os.environ:
             if TEST_MOTHERDUCK_TOKEN not in os.environ:
                 raise ValueError(
                     f"Please set the {MOTHERDUCK_TOKEN} or {TEST_MOTHERDUCK_TOKEN} \

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,9 @@ resource.setrlimit(resource.RLIMIT_NOFILE, (hard_limit, hard_limit))
 # Note: fixtures with session scope need to be local
 pytest_plugins = ["dbt.tests.fixtures.project"]
 
+MOTHERDUCK_TOKEN = "MOTHERDUCK_TOKEN"
+TEST_MOTHERDUCK_TOKEN = "TEST_MOTHERDUCK_TOKEN"
+
 
 def pytest_addoption(parser):
     parser.addoption("--profile", action="store", default="memory", type=str)
@@ -64,13 +67,13 @@ def dbt_profile_target(profile_type, bv_server_process, tmp_path_factory):
         profile["path"] = str(tmp_path_factory.getbasetemp() / "tmp.db")
     elif profile_type == "md":
         # Test against MotherDuck
-        if "MOTHERDUCK_TOKEN" not in os.environ:
-            if "TEST_MOTHERDUCK_TOKEN" not in os.environ:
+        if MOTHERDUCK_TOKEN not in os.environ or MOTHERDUCK_TOKEN.lower() not in os.environ:
+            if TEST_MOTHERDUCK_TOKEN not in os.environ:
                 raise ValueError(
-                    "Please set the MOTHERDUCK_TOKEN or TEST_MOTHERDUCK_TOKEN \
+                    f"Please set the {MOTHERDUCK_TOKEN} or {TEST_MOTHERDUCK_TOKEN} \
                         environment variable to run tests against MotherDuck"
                 )
-            profile["token"] = os.environ.get("TEST_MOTHERDUCK_TOKEN")
+            profile["token"] = os.environ.get(TEST_MOTHERDUCK_TOKEN)
         profile["disable_transactions"] = True
         profile["path"] = "md:test"
     elif profile_type == "memory":

--- a/tox.ini
+++ b/tox.ini
@@ -46,7 +46,7 @@ passenv = *
 commands = {envpython} -m pytest --profile=md --maxfail=2 {posargs} tests/functional/adapter tests/functional/plugins/test_motherduck.py
 deps =
   -rdev-requirements.txt
-  -e.
+  -e.[md]
 
 [testenv:{fsspec,py38,py39,py310,py311,py}]
 description = adapter fsspec testing


### PR DESCRIPTION
This PR fixes a bug:
- When passing a token via the config, this didn't work because there is a typo (by yours truly 😬) [here](https://github.com/duckdb/dbt-duckdb/blob/8a6e0dc33cfedd580be1b0a0a8e970b6fce05a5f/dbt/adapters/duckdb/plugins/motherduck.py#L16).

The PR also addresses how a user can pass the MotherDuck token to `duckdb.connect`:

- Adds a `motherduck_token` property to `DuckDBCredentials` that fetches it from the plugin config.
- The user can specify the token in the path (e.g. `"md:?motherduck_token=<token>"`. This will override a `motherduck_token` environment variable if it exists.
- We no longer use an explicit `SET` command and instead pass a `config` dictionary to `duckdb.connect`. Any config options passed this way will override the corresponding environment variable as well as any options set in the path.

So the behavior is now the same as in duckdb: env var < path < config. (where left < right means "right overrides left").