### PR TITLE
Migrate to dbt-common + dbt-adapters

### DIFF
--- a/dbt/adapters/duckdb/credentials.py
+++ b/dbt/adapters/duckdb/credentials.py
@@ -10,9 +10,10 @@ from typing import Optional
 from typing import Tuple
 from urllib.parse import urlparse
 
-import dbt.exceptions
-from dbt.adapters.base import Credentials
-from dbt.dataclass_schema import dbtClassMixin
+from dbt_common.dataclass_schema import dbtClassMixin
+from dbt_common.exceptions import DbtRuntimeError
+
+from dbt.adapters.contracts.connection import Credentials
 
 
 @dataclass
@@ -178,12 +179,12 @@ class DuckDBCredentials(Credentials):
             data["database"] = path_db
         elif path_db and data["database"] != path_db:
             if not data.get("remote"):
-                raise dbt.exceptions.DbtRuntimeError(
+                raise DbtRuntimeError(
                     "Inconsistency detected between 'path' and 'database' fields in profile; "
                     f"the 'database' property must be set to '{path_db}' to match the 'path'"
                 )
         elif not path_db:
-            raise dbt.exceptions.DbtRuntimeError(
+            raise DbtRuntimeError(
                 "Unable to determine target database name from 'path' field in profile"
             )
         return data

--- a/dbt/adapters/duckdb/environments/__init__.py
+++ b/dbt/adapters/duckdb/environments/__init__.py
@@ -9,13 +9,13 @@ from typing import List
 from typing import Optional
 
 import duckdb
+from dbt_common.exceptions import DbtRuntimeError
 
 from ..credentials import DuckDBCredentials
 from ..plugins import BasePlugin
 from ..utils import SourceConfig
 from ..utils import TargetConfig
-from dbt.contracts.connection import AdapterResponse
-from dbt.exceptions import DbtRuntimeError
+from dbt.adapters.contracts.connection import AdapterResponse
 
 
 def _ensure_event_loop():

--- a/dbt/adapters/duckdb/environments/buenavista.py
+++ b/dbt/adapters/duckdb/environments/buenavista.py
@@ -5,7 +5,7 @@ import psycopg2
 from . import Environment
 from .. import credentials
 from .. import utils
-from dbt.contracts.connection import AdapterResponse
+from dbt.adapters.contracts.connection import AdapterResponse
 
 
 class BVEnvironment(Environment):

--- a/dbt/adapters/duckdb/environments/local.py
+++ b/dbt/adapters/duckdb/environments/local.py
@@ -1,10 +1,11 @@
 import threading
 
+from dbt_common.exceptions import DbtRuntimeError
+
 from . import Environment
 from .. import credentials
 from .. import utils
-from dbt.contracts.connection import AdapterResponse
-from dbt.exceptions import DbtRuntimeError
+from dbt.adapters.contracts.connection import AdapterResponse
 
 
 class DuckDBCursorWrapper:

--- a/dbt/adapters/duckdb/impl.py
+++ b/dbt/adapters/duckdb/impl.py
@@ -5,11 +5,18 @@ from typing import Optional
 from typing import Sequence
 
 import agate
+from dbt_common.contracts.constraints import ColumnLevelConstraint
+from dbt_common.contracts.constraints import ConstraintType
+from dbt_common.exceptions import DbtInternalError
+from dbt_common.exceptions import DbtRuntimeError
 
 from dbt.adapters.base import BaseRelation
 from dbt.adapters.base.column import Column as BaseColumn
 from dbt.adapters.base.impl import ConstraintSupport
 from dbt.adapters.base.meta import available
+from dbt.adapters.contracts.connection import AdapterResponse
+from dbt.adapters.contracts.relation import Path
+from dbt.adapters.contracts.relation import RelationType
 from dbt.adapters.duckdb.column import DuckDBColumn
 from dbt.adapters.duckdb.connections import DuckDBConnectionManager
 from dbt.adapters.duckdb.relation import DuckDBRelation
@@ -17,13 +24,6 @@ from dbt.adapters.duckdb.utils import TargetConfig
 from dbt.adapters.duckdb.utils import TargetLocation
 from dbt.adapters.sql import SQLAdapter
 from dbt.context.providers import RuntimeConfigObject
-from dbt.contracts.connection import AdapterResponse
-from dbt.contracts.graph.nodes import ColumnLevelConstraint
-from dbt.contracts.graph.nodes import ConstraintType
-from dbt.contracts.relation import Path
-from dbt.contracts.relation import RelationType
-from dbt.exceptions import DbtInternalError
-from dbt.exceptions import DbtRuntimeError
 
 TEMP_SCHEMA_NAME = "temp_schema_name"
 DEFAULT_TEMP_SCHEMA_NAME = "dbt_temp"

--- a/dbt/adapters/duckdb/impl.py
+++ b/dbt/adapters/duckdb/impl.py
@@ -23,7 +23,8 @@ from dbt.adapters.duckdb.relation import DuckDBRelation
 from dbt.adapters.duckdb.utils import TargetConfig
 from dbt.adapters.duckdb.utils import TargetLocation
 from dbt.adapters.sql import SQLAdapter
-from dbt.context.providers import RuntimeConfigObject
+# TODO
+# from dbt.context.providers import RuntimeConfigObject
 
 TEMP_SCHEMA_NAME = "temp_schema_name"
 DEFAULT_TEMP_SCHEMA_NAME = "dbt_temp"
@@ -99,7 +100,7 @@ class DuckDBAdapter(SQLAdapter):
         column_list: Sequence[BaseColumn],
         path: str,
         format: str,
-        config: RuntimeConfigObject,
+        config: Any,
     ) -> None:
         target_config = TargetConfig(
             relation=relation,

--- a/dbt/adapters/duckdb/plugins/__init__.py
+++ b/dbt/adapters/duckdb/plugins/__init__.py
@@ -4,12 +4,12 @@ from typing import Any
 from typing import Dict
 from typing import Optional
 
+from dbt_common.dataclass_schema import dbtClassMixin
 from duckdb import DuckDBPyConnection
 
 from ..credentials import DuckDBCredentials
 from ..utils import SourceConfig
 from ..utils import TargetConfig
-from dbt.dataclass_schema import dbtClassMixin
 
 
 class PluginConfig(dbtClassMixin):

--- a/dbt/adapters/duckdb/relation.py
+++ b/dbt/adapters/duckdb/relation.py
@@ -7,12 +7,9 @@ from typing import Type
 from .connections import DuckDBConnectionManager
 from .utils import SourceConfig
 from dbt.adapters.base.relation import BaseRelation
-from dbt.adapters.base.relation import Self
+from dbt.adapters.contracts.relation import HasQuoting
+from dbt.adapters.contracts.relation import RelationConfig
 
-from dbt.adapters.contracts.relation import (
-    HasQuoting,
-    RelationConfig,
-)
 
 @dataclass(frozen=True, eq=False, repr=False)
 class DuckDBRelation(BaseRelation):
@@ -20,18 +17,20 @@ class DuckDBRelation(BaseRelation):
 
     @classmethod
     def create_from(
-        cls: Type[Self],
+        cls: Type["DuckDBRelation"],
         quoting: HasQuoting,
         relation_config: RelationConfig,
         **kwargs: Any,
-    ) -> Self:
-        if relation_config.resource_type == 'source':
+    ) -> "DuckDBRelation":
+        if relation_config.resource_type == "source":
             return cls.create_from_source(quoting, relation_config, **kwargs)
         else:
             return super().create_from(quoting, relation_config, **kwargs)
 
     @classmethod
-    def create_from_source(cls: Type[Self], quoting: HasQuoting, source: RelationConfig, **kwargs: Any) -> Self:
+    def create_from_source(
+        cls: Type["DuckDBRelation"], quoting: HasQuoting, source: RelationConfig, **kwargs: Any
+    ) -> "DuckDBRelation":
         """
         This method creates a new DuckDBRelation instance from a source definition.
         It first checks if a 'plugin' is defined in the meta argument for the source or its parent configuration.

--- a/dbt/adapters/duckdb/utils.py
+++ b/dbt/adapters/duckdb/utils.py
@@ -51,7 +51,8 @@ class SourceConfig:
     def create_from_source(cls, source: RelationConfig) -> "SourceConfig":
         meta = source.meta.copy()
         # Use the config properties as well if they are present
-        meta.update(source.config.extra)
+        config_properties = source.config.extra if source.config else {}
+        meta.update(config_properties)
         return SourceConfig(
             name=source.name,
             identifier=source.identifier,

--- a/dbt/adapters/duckdb/utils.py
+++ b/dbt/adapters/duckdb/utils.py
@@ -7,9 +7,9 @@ from typing import Sequence
 
 from dbt.adapters.base.column import Column
 from dbt.adapters.base.relation import BaseRelation
+from dbt.adapters.contracts.relation import RelationConfig
 # TODO
 # from dbt.context.providers import RuntimeConfigObject
-# from dbt_common.contracts.graph.nodes import SourceDefinition
 
 
 @dataclass
@@ -48,7 +48,7 @@ class SourceConfig:
         return base
 
     @classmethod
-    def create_from_source(cls, source: Any) -> "SourceConfig":
+    def create_from_source(cls, source: RelationConfig) -> "SourceConfig":
         meta = source.source_meta.copy()
         meta.update(source.meta)
         # Use the config properties as well if they are present

--- a/dbt/adapters/duckdb/utils.py
+++ b/dbt/adapters/duckdb/utils.py
@@ -49,10 +49,9 @@ class SourceConfig:
 
     @classmethod
     def create_from_source(cls, source: RelationConfig) -> "SourceConfig":
-        meta = source.source_meta.copy()
-        meta.update(source.meta)
+        meta = source.meta.copy()
         # Use the config properties as well if they are present
-        meta.update(source.config._extra)
+        meta.update(source.config.extra)
         return SourceConfig(
             name=source.name,
             identifier=source.identifier,

--- a/dbt/adapters/duckdb/utils.py
+++ b/dbt/adapters/duckdb/utils.py
@@ -7,8 +7,9 @@ from typing import Sequence
 
 from dbt.adapters.base.column import Column
 from dbt.adapters.base.relation import BaseRelation
-from dbt.context.providers import RuntimeConfigObject
-from dbt.contracts.graph.nodes import SourceDefinition
+# TODO
+# from dbt.context.providers import RuntimeConfigObject
+# from dbt_common.contracts.graph.nodes import SourceDefinition
 
 
 @dataclass
@@ -47,7 +48,7 @@ class SourceConfig:
         return base
 
     @classmethod
-    def create_from_source(cls, source: SourceDefinition) -> "SourceConfig":
+    def create_from_source(cls, source: Any) -> "SourceConfig":
         meta = source.source_meta.copy()
         meta.update(source.meta)
         # Use the config properties as well if they are present
@@ -75,7 +76,7 @@ class TargetLocation:
 class TargetConfig:
     relation: BaseRelation
     column_list: Sequence[Column]
-    config: RuntimeConfigObject
+    config: Any  # TODO
     location: Optional[TargetLocation] = None
 
     def as_dict(self) -> Dict[str, Any]:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 # install latest changes in dbt-core + dbt-tests-adapter
-git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-core&subdirectory=core
-git+https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-tests-adapter
+# git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-core&subdirectory=core
+# git+https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-tests-adapter
 
 boto3
 mypy-boto3-glue

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,6 +2,8 @@
 # git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-core&subdirectory=core
 # git+https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-tests-adapter
 
+dbt-tests-adapter>=1.8.0b1
+
 boto3
 mypy-boto3-glue
 pandas

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,8 +1,6 @@
-# install latest changes in dbt-core
-# git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-core&subdirectory=core
-# git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-tests-adapter&subdirectory=tests/adapter
-
-dbt-tests-adapter==1.7.7
+# install latest changes in dbt-tests-adapter
+git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-core&subdirectory=core
+git+https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-tests-adapter
 
 boto3
 mypy-boto3-glue

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-# install latest changes in dbt-tests-adapter
+# install latest changes in dbt-core + dbt-tests-adapter
 git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-core&subdirectory=core
 git+https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-tests-adapter
 

--- a/setup.py
+++ b/setup.py
@@ -37,8 +37,8 @@ setup(
     packages=find_namespace_packages(include=["dbt", "dbt.*"]),
     include_package_data=True,
     install_requires=[
-        "dbt-common>=0.1.0,<0.2.0",
-        "dbt-adapters>=0.1.0a1,<0.2.0",
+        "dbt-common>=1.0.0b1,<2.0",
+        "dbt-adapters>=1.0.0b1,<2.0",
         "duckdb>=0.7.0",
     ],
     extras_require={"glue": ["boto3", "mypy-boto3-glue"], "md": ["duckdb>=0.7.0,<=0.9.2"]},

--- a/setup.py
+++ b/setup.py
@@ -37,8 +37,8 @@ setup(
     packages=find_namespace_packages(include=["dbt", "dbt.*"]),
     include_package_data=True,
     install_requires=[
-        "dbt-common<1.0",
-        "dbt-adapters<=0.2.0",
+        "dbt-common>=0.1.0,<0.2.0",
+        "dbt-adapters>=0.1.0a1,<0.2.0",
         "duckdb>=0.7.0",
     ],
     extras_require={"glue": ["boto3", "mypy-boto3-glue"], "md": ["duckdb>=0.7.0,<=0.9.2"]},

--- a/setup.py
+++ b/setup.py
@@ -37,9 +37,11 @@ setup(
     packages=find_namespace_packages(include=["dbt", "dbt.*"]),
     include_package_data=True,
     install_requires=[
-        "dbt-common>=1.0.0b1,<2.0",
-        "dbt-adapters>=1.0.0b1,<2.0",
+        "dbt-common>=1,<2",
+        "dbt-adapters>=1,<2",
         "duckdb>=0.7.0",
+        # add dbt-core to ensure backwards compatibility of installation, this is not a functional dependency
+        "dbt-core>=1.8.0b1",
     ],
     extras_require={"glue": ["boto3", "mypy-boto3-glue"], "md": ["duckdb>=0.7.0,<=0.9.2"]},
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,8 @@ setup(
     packages=find_namespace_packages(include=["dbt", "dbt.*"]),
     include_package_data=True,
     install_requires=[
-        "dbt-core~=1.7.0",
+        "dbt-common<1.0",
+        "dbt-adapters<=0.2.0",
         "duckdb>=0.7.0",
     ],
     extras_require={"glue": ["boto3", "mypy-boto3-glue"], "md": ["duckdb>=0.7.0,<=0.9.2"]},

--- a/tests/functional/adapter/test_unit_testing.py
+++ b/tests/functional/adapter/test_unit_testing.py
@@ -1,0 +1,35 @@
+import pytest
+
+from dbt.tests.adapter.unit_testing.test_types import BaseUnitTestingTypes
+from dbt.tests.adapter.unit_testing.test_case_insensitivity import BaseUnitTestCaseInsensivity
+from dbt.tests.adapter.unit_testing.test_invalid_input import BaseUnitTestInvalidInput
+
+
+class TestUnitTestingTypesDuckDB(BaseUnitTestingTypes):
+    @pytest.fixture
+    def data_types(self):
+        # sql_value, yaml_value
+        return [
+            ["1", "1"],
+            ["2.0", "2.0"],
+            ["'12345'", "12345"],
+            ["'string'", "string"],
+            ["true", "true"],
+            ["DATE '2020-01-02'", "2020-01-02"],
+            ["TIMESTAMP '2013-11-03 00:00:00-0'", "2013-11-03 00:00:00-0"],
+            ["'2013-11-03 00:00:00-0'::TIMESTAMPTZ", "2013-11-03 00:00:00-0"],
+            [
+                "{'Alberta':'Edmonton','Manitoba':'Winnipeg'}",
+                "{'Alberta':'Edmonton','Manitoba':'Winnipeg'}",
+            ],
+            ["ARRAY['a','b','c']", "['a','b','c']"],
+            ["ARRAY[1,2,3]", "[1, 2, 3]"],
+        ]
+
+
+class TestUnitTestCaseInsensitivityDuckDB(BaseUnitTestCaseInsensivity):
+    pass
+
+
+class TestUnitTestInvalidInputDuckDB(BaseUnitTestInvalidInput):
+    pass

--- a/tests/functional/adapter/test_unit_testing.py
+++ b/tests/functional/adapter/test_unit_testing.py
@@ -5,6 +5,7 @@ from dbt.tests.adapter.unit_testing.test_case_insensitivity import BaseUnitTestC
 from dbt.tests.adapter.unit_testing.test_invalid_input import BaseUnitTestInvalidInput
 
 
+@pytest.mark.skip_profile("buenavista")
 class TestUnitTestingTypesDuckDB(BaseUnitTestingTypes):
     @pytest.fixture
     def data_types(self):

--- a/tests/unit/test_duckdb_adapter.py
+++ b/tests/unit/test_duckdb_adapter.py
@@ -39,8 +39,9 @@ class TestDuckDBAdapter(unittest.TestCase):
 
     @property
     def adapter(self):
+        self.mock_mp_context = mock.MagicMock()
         if self._adapter is None:
-            self._adapter = DuckDBAdapter(self.config)
+            self._adapter = DuckDBAdapter(self.config, self.mock_mp_context)
         return self._adapter
 
     @mock.patch("dbt.adapters.duckdb.environments.duckdb")

--- a/tests/unit/test_external_utils.py
+++ b/tests/unit/test_external_utils.py
@@ -1,5 +1,6 @@
 import unittest
 from argparse import Namespace
+from unittest import mock
 
 from dbt.flags import set_from_args
 from dbt.adapters.duckdb import DuckDBAdapter
@@ -32,8 +33,9 @@ class TestExternalUtils(unittest.TestCase):
 
     @property
     def adapter(self):
+        self.mock_mp_context = mock.MagicMock()
         if self._adapter is None:
-            self._adapter = DuckDBAdapter(self.config)
+            self._adapter = DuckDBAdapter(self.config, self.mock_mp_context)
         return self._adapter
 
     def test_external_write_options(self):


### PR DESCRIPTION
resolves #341

Starting a draft PR for discussion!

This mostly just works by updating `import` statements. Caveats:
- In `dbt.adapters.duckdb.utils`: `SourceConfig` and `TargetConfig` use type definitions that are not available from the common/adapter interfaces. We could either stub those types within `duckdb.utils`, or discuss if they need to be pulled into the shared interfaces.
- Some of the plugin tests are failing for me locally. I'd like to see if these are real issues, or just problems with my local setup.