### PR TITLE
Fix: dbt-duckdb runs SET custom_user_agent after connect

### DIFF
--- a/dbt/adapters/duckdb/plugins/motherduck.py
+++ b/dbt/adapters/duckdb/plugins/motherduck.py
@@ -35,7 +35,7 @@ class Plugin(BasePlugin):
             user_agent = f"{user_agent} {config['custom_user_agent']}"
         settings: Dict[str, Any] = creds.settings or {}
         if "custom_user_agent" in settings:
-            user_agent = f"{user_agent} {creds.settings.pop('custom_user_agent')}"
+            user_agent = f"{user_agent} {settings.pop('custom_user_agent')}"
 
         config["custom_user_agent"] = user_agent
 

--- a/dbt/adapters/duckdb/plugins/motherduck.py
+++ b/dbt/adapters/duckdb/plugins/motherduck.py
@@ -33,7 +33,8 @@ class Plugin(BasePlugin):
         user_agent = f"dbt/{__version__}"
         if "custom_user_agent" in config:
             user_agent = f"{user_agent} {config['custom_user_agent']}"
-        if "custom_user_agent" in creds.settings or {}:
+        settings: Dict[str, Any] = creds.settings or {}
+        if "custom_user_agent" in settings:
             user_agent = f"{user_agent} {creds.settings.pop('custom_user_agent')}"
 
         config["custom_user_agent"] = user_agent

--- a/dbt/adapters/duckdb/plugins/motherduck.py
+++ b/dbt/adapters/duckdb/plugins/motherduck.py
@@ -33,6 +33,8 @@ class Plugin(BasePlugin):
         user_agent = f"dbt/{__version__}"
         if "custom_user_agent" in config:
             user_agent = f"{user_agent} {config['custom_user_agent']}"
+        if "custom_user_agent" in creds.settings:
+            user_agent = f"{user_agent} {creds.settings.pop('custom_user_agent')}"
 
         config["custom_user_agent"] = user_agent
 

--- a/dbt/adapters/duckdb/plugins/motherduck.py
+++ b/dbt/adapters/duckdb/plugins/motherduck.py
@@ -33,7 +33,7 @@ class Plugin(BasePlugin):
         user_agent = f"dbt/{__version__}"
         if "custom_user_agent" in config:
             user_agent = f"{user_agent} {config['custom_user_agent']}"
-        if "custom_user_agent" in creds.settings:
+        if "custom_user_agent" in creds.settings or {}:
             user_agent = f"{user_agent} {creds.settings.pop('custom_user_agent')}"
 
         config["custom_user_agent"] = user_agent

--- a/tests/functional/plugins/test_motherduck.py
+++ b/tests/functional/plugins/test_motherduck.py
@@ -132,11 +132,15 @@ def mock_plugins(mock_creds, mock_md_plugin):
 
 def test_motherduck_user_agent(dbt_profile_target, mock_plugins, mock_creds):
     with mock.patch("dbt.adapters.duckdb.environments.duckdb.connect") as mock_connect:
+        mock_creds.settings = {"custom_user_agent": "downstream-dep"}
         Environment.initialize_db(mock_creds, plugins=mock_plugins)
         if mock_creds.is_motherduck:
             kwargs = {
                 'read_only': False,
-                'config': {'custom_user_agent': f'dbt/{__version__}', 'motherduck_token': 'quack'}
+                'config': {
+                    'custom_user_agent': f'dbt/{__version__} downstream-dep',
+                    'motherduck_token': 'quack'
+                }
             }
             mock_connect.assert_called_with(dbt_profile_target["path"], **kwargs)
         else:


### PR DESCRIPTION
When connecting to MotherDuck, if `custom_user_agent` is passed via `settings` in the profiles.yml file, `dbt run` throws an error:
![image](https://github.com/duckdb/dbt-duckdb/assets/4041805/cbece3af-8f74-404f-a8bd-f51d77056ed1)

This fix pops the value from `settings` if it's defined and concatenates it at the end of the existing `custom_user_agent`.