### PR TITLE
Fix: custom_user_agent does not work if motherduck plugin is not specified in profiles.yml

### DIFF
--- a/dbt/adapters/duckdb/credentials.py
+++ b/dbt/adapters/duckdb/credentials.py
@@ -146,6 +146,15 @@ class DuckDBCredentials(Credentials):
     # by networking issues)
     retries: Optional[Retries] = None
 
+    def __post_init__(self):
+        # Add MotherDuck plugin if the path is a MotherDuck database
+        # and plugin was not specified in profile.yml
+        if self.is_motherduck:
+            if self.plugins is None:
+                self.plugins = []
+            if "motherduck" not in [plugin["module"] for plugin in self.plugins]:
+                self.plugins.append(PluginConfig(module="motherduck"))
+
     @property
     def is_motherduck(self):
         parsed = urlparse(self.path)

--- a/dbt/adapters/duckdb/plugins/motherduck.py
+++ b/dbt/adapters/duckdb/plugins/motherduck.py
@@ -4,9 +4,9 @@ from typing import Dict
 from duckdb import DuckDBPyConnection
 
 from . import BasePlugin
+from dbt.adapters.duckdb.__version__ import version as __plugin_version__
 from dbt.adapters.duckdb.credentials import DuckDBCredentials
 from dbt.version import __version__
-from dbt.adapters.duckdb.__version__ import version as __plugin_version__
 
 
 class Plugin(BasePlugin):

--- a/dbt/adapters/duckdb/plugins/motherduck.py
+++ b/dbt/adapters/duckdb/plugins/motherduck.py
@@ -6,6 +6,7 @@ from duckdb import DuckDBPyConnection
 from . import BasePlugin
 from dbt.adapters.duckdb.credentials import DuckDBCredentials
 from dbt.version import __version__
+from dbt.adapters.duckdb.__version__ import version as __plugin_version__
 
 
 class Plugin(BasePlugin):
@@ -30,7 +31,7 @@ class Plugin(BasePlugin):
         return ""
 
     def update_connection_config(self, creds: DuckDBCredentials, config: Dict[str, Any]):
-        user_agent = f"dbt/{__version__}"
+        user_agent = f"dbt/{__version__} dbt-duckdb/{__plugin_version__}"
         if "custom_user_agent" in config:
             user_agent = f"{user_agent} {config['custom_user_agent']}"
         settings: Dict[str, Any] = creds.settings or {}


### PR DESCRIPTION
We weren't seeing any `custom_user_agent` coming through - turns out the `motherduck` plugin needs to be specified explicitly.
This PR adds the plugin to `DuckDBCredentials` if a MotherDuck database is specified.