### PR TITLE
lazy load agate

### DIFF
--- a/dbt/adapters/duckdb/connections.py
+++ b/dbt/adapters/duckdb/connections.py
@@ -3,8 +3,7 @@ import threading
 from contextlib import contextmanager
 from typing import Optional
 from typing import Tuple
-
-import agate
+from typing import TYPE_CHECKING
 
 import dbt.exceptions
 from . import environments
@@ -14,6 +13,9 @@ from dbt.contracts.connection import AdapterResponse
 from dbt.contracts.connection import Connection
 from dbt.contracts.connection import ConnectionState
 from dbt.logger import GLOBAL_LOGGER as logger
+
+if TYPE_CHECKING:
+    import agate
 
 
 class DuckDBConnectionManager(SQLConnectionManager):
@@ -101,7 +103,7 @@ class DuckDBConnectionManager(SQLConnectionManager):
         auto_begin: bool = False,
         fetch: bool = False,
         limit: Optional[int] = None,
-    ) -> Tuple[AdapterResponse, agate.Table]:
+    ) -> Tuple[AdapterResponse, "agate.Table"]:
         if self.disable_transactions:
             auto_begin = False
         return super().execute(sql, auto_begin, fetch, limit)

--- a/dbt/adapters/duckdb/impl.py
+++ b/dbt/adapters/duckdb/impl.py
@@ -5,7 +5,6 @@ from typing import Optional
 from typing import Sequence
 from typing import TYPE_CHECKING
 
-
 from dbt.adapters.base import BaseRelation
 from dbt.adapters.base.column import Column as BaseColumn
 from dbt.adapters.base.impl import ConstraintSupport
@@ -66,6 +65,7 @@ class DuckDBAdapter(SQLAdapter):
     @available
     def convert_datetimes_to_strs(self, table: "agate.Table") -> "agate.Table":
         import agate
+
         for column in table.columns:
             if isinstance(column.data_type, agate.DateTime):
                 table = table.compute(

--- a/dbt/adapters/duckdb/impl.py
+++ b/dbt/adapters/duckdb/impl.py
@@ -3,8 +3,8 @@ from typing import Any
 from typing import List
 from typing import Optional
 from typing import Sequence
+from typing import TYPE_CHECKING
 
-import agate
 
 from dbt.adapters.base import BaseRelation
 from dbt.adapters.base.column import Column as BaseColumn
@@ -27,6 +27,9 @@ from dbt.exceptions import DbtRuntimeError
 
 TEMP_SCHEMA_NAME = "temp_schema_name"
 DEFAULT_TEMP_SCHEMA_NAME = "dbt_temp"
+
+if TYPE_CHECKING:
+    import agate
 
 
 class DuckDBAdapter(SQLAdapter):
@@ -61,7 +64,8 @@ class DuckDBAdapter(SQLAdapter):
         return self.config.credentials.is_motherduck
 
     @available
-    def convert_datetimes_to_strs(self, table: agate.Table) -> agate.Table:
+    def convert_datetimes_to_strs(self, table: "agate.Table") -> "agate.Table":
+        import agate
         for column in table.columns:
             if isinstance(column.data_type, agate.DateTime):
                 table = table.compute(


### PR DESCRIPTION
TLDR:

- Lazy loading `agate` saves 3.5% load-up time on all operations that don't require agate. (aka many of them)
- dbt labs is on board with this, it's already been implemented in `dbt-core` and it's likely to be implemented in `dbt-adapters`: https://github.com/dbt-labs/dbt-adapters/pull/126