### PR TITLE
Only run MotherDuck integration tests on master, skip for pull requests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ name: Tests and Code Checks
 on:
   push:
     branches:
-      - "main"
+      - "master"
       - "develop"
       - "*.latest"
       - "releases/*"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -200,8 +200,22 @@ jobs:
           name: filebased_results_${{ matrix.python-version }}-${{ steps.date.outputs.date }}.csv
           path: filebased_results.csv
 
+  check-md-token:
+    name: Check if MotherDuck token exists
+    runs-on: ubuntu-latest
+    outputs:
+      exists: ${{ steps.md-token.outputs.exists }}
+    steps:
+        - id: md-token
+          env:
+              MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
+          if: ${{ env.MOTHERDUCK_TOKEN != '' }}
+          run: echo "::set-output name=exists::true"
+
   motherduck:
     name: MotherDuck functional test / python ${{ matrix.python-version }}
+    needs: [check-md-token]
+    if: needs.check-md-token.outputs.exists == 'true'
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
This PR adds a job that checks if the MotherDuck token is defined, and only runs the integration tests if it is. This way the job is just skipped instead of failing with a `Cannot connect to MotherDuck server: no token provided.` error.
Additionally, I've updated the `push` trigger branch name to `master` so the tests always run after PRs are merged.

For more detailed info see:

https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
https://gist.github.com/GuillaumeFalourd/d3524cf6361afad87b9da3bf78270bc1