### PR TITLE
query cancellation attempt

### DIFF
--- a/dbt/adapters/duckdb/connections.py
+++ b/dbt/adapters/duckdb/connections.py
@@ -65,8 +65,11 @@ class DuckDBConnectionManager(SQLConnectionManager):
         connection = super(SQLConnectionManager, cls).close(connection)
         return connection
 
-    def cancel(self, connection):
-        pass
+    def cancel(self, connection: Connection):
+        logger.debug("cancelling query on connection {}. Details: {}".format(connection.name, connection))
+        self._ENV.cancel(connection)
+        logger.debug("query cancelled on connection {}".format(connection.name))
+
 
     @contextmanager
     def exception_handler(self, sql: str, connection_name="master"):

--- a/dbt/adapters/duckdb/connections.py
+++ b/dbt/adapters/duckdb/connections.py
@@ -65,12 +65,15 @@ class DuckDBConnectionManager(SQLConnectionManager):
         connection = super(SQLConnectionManager, cls).close(connection)
         return connection
 
-
-    def cancel(cls, connection: Connection):
-        logger.debug("cancelling query on connection {}. Details: {}".format(connection.name, connection))
-        cls._ENV.cancel(connection)
-        logger.debug("query cancelled on connection {}".format(connection.name))
-
+    def cancel(self, connection: Connection):
+        if self._ENV is not None:
+            logger.debug(
+                "cancelling query on connection {}. Details: {}".format(
+                    connection.name, connection
+                )
+            )
+            self._ENV.cancel(connection)
+            logger.debug("query cancelled on connection {}".format(connection.name))
 
     @contextmanager
     def exception_handler(self, sql: str, connection_name="master"):

--- a/dbt/adapters/duckdb/connections.py
+++ b/dbt/adapters/duckdb/connections.py
@@ -65,9 +65,10 @@ class DuckDBConnectionManager(SQLConnectionManager):
         connection = super(SQLConnectionManager, cls).close(connection)
         return connection
 
-    def cancel(self, connection: Connection):
+
+    def cancel(cls, connection: Connection):
         logger.debug("cancelling query on connection {}. Details: {}".format(connection.name, connection))
-        self._ENV.cancel(connection)
+        cls._ENV.cancel(connection)
         logger.debug("query cancelled on connection {}".format(connection.name))
 
 

--- a/dbt/adapters/duckdb/environments/__init__.py
+++ b/dbt/adapters/duckdb/environments/__init__.py
@@ -120,6 +120,11 @@ class Environment(abc.ABC):
     
     @classmethod
     @abc.abstractmethod
+    def is_cancelable(cls) -> bool:
+        pass
+
+    @classmethod
+    @abc.abstractmethod
     def cancel(cls, connection: Connection):
         pass
 

--- a/dbt/adapters/duckdb/environments/__init__.py
+++ b/dbt/adapters/duckdb/environments/__init__.py
@@ -14,7 +14,7 @@ from ..credentials import DuckDBCredentials
 from ..plugins import BasePlugin
 from ..utils import SourceConfig
 from ..utils import TargetConfig
-from dbt.contracts.connection import AdapterResponse
+from dbt.contracts.connection import AdapterResponse, Connection
 from dbt.exceptions import DbtRuntimeError
 
 
@@ -114,9 +114,14 @@ class Environment(abc.ABC):
 
     def get_binding_char(self) -> str:
         return "?"
-
+    
     def supports_comments(self) -> bool:
         return self._supports_comments
+    
+    @classmethod
+    @abc.abstractmethod
+    def cancel(cls, connection: Connection):
+        pass
 
     @classmethod
     def initialize_db(

--- a/dbt/adapters/duckdb/environments/__init__.py
+++ b/dbt/adapters/duckdb/environments/__init__.py
@@ -14,7 +14,8 @@ from ..credentials import DuckDBCredentials
 from ..plugins import BasePlugin
 from ..utils import SourceConfig
 from ..utils import TargetConfig
-from dbt.contracts.connection import AdapterResponse, Connection
+from dbt.contracts.connection import AdapterResponse
+from dbt.contracts.connection import Connection
 from dbt.exceptions import DbtRuntimeError
 
 
@@ -114,10 +115,10 @@ class Environment(abc.ABC):
 
     def get_binding_char(self) -> str:
         return "?"
-    
+
     def supports_comments(self) -> bool:
         return self._supports_comments
-    
+
     @classmethod
     @abc.abstractmethod
     def is_cancelable(cls) -> bool:

--- a/dbt/adapters/duckdb/environments/buenavista.py
+++ b/dbt/adapters/duckdb/environments/buenavista.py
@@ -5,7 +5,8 @@ import psycopg2
 from . import Environment
 from .. import credentials
 from .. import utils
-from dbt.contracts.connection import AdapterResponse, Connection
+from dbt.contracts.connection import AdapterResponse
+from dbt.contracts.connection import Connection
 
 
 class BVEnvironment(Environment):
@@ -30,10 +31,10 @@ class BVEnvironment(Environment):
         cursor = self.initialize_cursor(self.creds, conn.cursor())
         cursor.close()
         return conn
-    
+
     def is_cancelable(cls):
         return False
-    
+
     @classmethod
     def cancel(cls, connection: Connection):
         pass

--- a/dbt/adapters/duckdb/environments/buenavista.py
+++ b/dbt/adapters/duckdb/environments/buenavista.py
@@ -31,6 +31,9 @@ class BVEnvironment(Environment):
         cursor.close()
         return conn
     
+    def is_cancelable(cls):
+        return False
+    
     @classmethod
     def cancel(cls, connection: Connection):
         pass

--- a/dbt/adapters/duckdb/environments/buenavista.py
+++ b/dbt/adapters/duckdb/environments/buenavista.py
@@ -5,7 +5,7 @@ import psycopg2
 from . import Environment
 from .. import credentials
 from .. import utils
-from dbt.contracts.connection import AdapterResponse
+from dbt.contracts.connection import AdapterResponse, Connection
 
 
 class BVEnvironment(Environment):
@@ -30,6 +30,10 @@ class BVEnvironment(Environment):
         cursor = self.initialize_cursor(self.creds, conn.cursor())
         cursor.close()
         return conn
+    
+    @classmethod
+    def cancel(cls, connection: Connection):
+        pass
 
     def get_binding_char(self) -> str:
         return "%s"

--- a/dbt/adapters/duckdb/environments/local.py
+++ b/dbt/adapters/duckdb/environments/local.py
@@ -3,7 +3,8 @@ import threading
 from . import Environment
 from .. import credentials
 from .. import utils
-from dbt.contracts.connection import AdapterResponse, Connection
+from dbt.contracts.connection import AdapterResponse
+from dbt.contracts.connection import Connection
 from dbt.exceptions import DbtRuntimeError
 
 
@@ -60,7 +61,8 @@ class LocalEnvironment(Environment):
 
     def is_cancelable(cls):
         return True
-    
+
+    @classmethod
     def cancel(cls, connection: Connection):
         connection.handle.cursor().interrupt()
 

--- a/dbt/adapters/duckdb/environments/local.py
+++ b/dbt/adapters/duckdb/environments/local.py
@@ -58,6 +58,9 @@ class LocalEnvironment(Environment):
             if self.handle_count == 0 and not self._keep_open:
                 self.close()
 
+    def is_cancelable(cls):
+        return True
+    
     def cancel(cls, connection: Connection):
         connection.handle.cursor().interrupt()
 

--- a/dbt/adapters/duckdb/environments/local.py
+++ b/dbt/adapters/duckdb/environments/local.py
@@ -3,7 +3,7 @@ import threading
 from . import Environment
 from .. import credentials
 from .. import utils
-from dbt.contracts.connection import AdapterResponse
+from dbt.contracts.connection import AdapterResponse, Connection
 from dbt.exceptions import DbtRuntimeError
 
 
@@ -57,6 +57,9 @@ class LocalEnvironment(Environment):
             self.handle_count -= 1
             if self.handle_count == 0 and not self._keep_open:
                 self.close()
+
+    def cancel(cls, connection: Connection):
+        connection.handle.cursor().interrupt()
 
     def handle(self):
         # Extensions/settings need to be configured per cursor

--- a/dbt/adapters/duckdb/impl.py
+++ b/dbt/adapters/duckdb/impl.py
@@ -54,7 +54,7 @@ class DuckDBAdapter(SQLAdapter):
     @classmethod
     def is_cancelable(cls) -> bool:
         return cls.ConnectionManager.env().is_cancelable()
-    
+
     def debug_query(self):
         self.execute("select 1 as id")
 

--- a/dbt/adapters/duckdb/impl.py
+++ b/dbt/adapters/duckdb/impl.py
@@ -51,10 +51,6 @@ class DuckDBAdapter(SQLAdapter):
     def date_function(cls) -> str:
         return "now()"
 
-    @classmethod
-    def is_cancelable(cls) -> bool:
-        return False
-
     def debug_query(self):
         self.execute("select 1 as id")
 

--- a/dbt/adapters/duckdb/impl.py
+++ b/dbt/adapters/duckdb/impl.py
@@ -51,6 +51,10 @@ class DuckDBAdapter(SQLAdapter):
     def date_function(cls) -> str:
         return "now()"
 
+    @classmethod
+    def is_cancelable(cls) -> bool:
+        return cls.ConnectionManager.env().is_cancelable()
+    
     def debug_query(self):
         self.execute("select 1 as id")
 


### PR DESCRIPTION
Implement query cancellation for DuckDB/MotherDuck using conn.interrupt() https://github.com/duckdb/duckdb/pull/7895 