### PR TITLE
Update the devcontainer/pre-commit to use Python 3.11

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
 			// Update 'VARIANT' to pick a Python version: 3, 3.10, 3.9, 3.8, 3.7, 3.6
 			// Append -bullseye or -buster to pin to an OS version.
 			// Use -bullseye variants on local on arm64/Apple Silicon.
-			"VARIANT": "3.8",
+			"VARIANT": "3.11",
 			// Options
 			"NODE_VERSION": "none"
 		}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: '3.11'
 
       - name: Install python dependencies
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ exclude: "^tests/.*"
 
 
 default_language_version:
-  python: python3.8
+  python: python3.11
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/dbt/adapters/duckdb/credentials.py
+++ b/dbt/adapters/duckdb/credentials.py
@@ -235,9 +235,7 @@ class DuckDBCredentials(Credentials):
         if self.use_credential_provider:
             if self.use_credential_provider == "aws":
                 settings.update(
-                    _load_aws_credentials(
-                        ttl=_get_ttl_hash(), profile=settings.get("s3_profile")
-                    ),
+                    _load_aws_credentials(ttl=_get_ttl_hash(), profile=settings.get("s3_profile")),
                 )
             else:
                 raise ValueError(


### PR DESCRIPTION
Hopefully this makes it easier to run this locally and puts us on a good footing as 3.8 heads for EOL in October