### PR TITLE
Bump md duckdb version to 0.10.2 and use new token

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -201,14 +201,14 @@ jobs:
           path: filebased_results.csv
 
   check-md-token:
-    name: Check if MotherDuck token exists
+    name: Check if MotherDuck v0.10.x token exists
     runs-on: ubuntu-latest
     outputs:
       exists: ${{ steps.md-token.outputs.exists }}
     steps:
         - id: md-token
           env:
-              MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
+              MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN_10 }}
           if: ${{ env.MOTHERDUCK_TOKEN != '' }}
           run: echo "::set-output name=exists::true"
 
@@ -226,7 +226,7 @@ jobs:
 
     env:
       TOXENV: "md"
-      MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
+      MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN_10 }}
       PYTEST_ADDOPTS: "-v --color=yes --csv motherduck_results.csv"
 
     steps:
@@ -362,7 +362,7 @@ jobs:
 
     env:
       TOXENV: "plugins"
-      MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
+      MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN_10 }}
       PYTEST_ADDOPTS: "-v --color=yes --csv plugins_results.csv"
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         "dbt-core~=1.7.0",
         "duckdb>=0.7.0",
     ],
-    extras_require={"glue": ["boto3", "mypy-boto3-glue"], "md": ["duckdb>=0.7.0,<=0.9.2"]},
+    extras_require={"glue": ["boto3", "mypy-boto3-glue"], "md": ["duckdb>=0.10.2"]},
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
This bumps the DuckDB version to 0.10.2 for MotherDuck integration tests. I've added a new secret `MOTHERDUCK_TOKEN_10` that I set up specifically for this pipeline that we can use here and is on the MD 0.10.x preview. I kept the `MOTHERDUCK_TOKEN` for now in case we need to revert back to that for some reason.