### PR TITLE
Pin to duckdb v0.10.2 to avoid view dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     install_requires=[
         "dbt-common>=1,<2",
         "dbt-adapters>=1,<2",
-        "duckdb!=0.10.3",
+        "duckdb>=0.7.0,!=0.10.3",
         # add dbt-core to ensure backwards compatibility of installation, this is not a functional dependency
         "dbt-core>=1.8.0",
     ],

--- a/setup.py
+++ b/setup.py
@@ -39,11 +39,11 @@ setup(
     install_requires=[
         "dbt-common>=1,<2",
         "dbt-adapters>=1,<2",
-        "duckdb>=0.7.0",
+        "duckdb!=0.10.3",
         # add dbt-core to ensure backwards compatibility of installation, this is not a functional dependency
         "dbt-core>=1.8.0",
     ],
-    extras_require={"glue": ["boto3", "mypy-boto3-glue"], "md": ["duckdb>=0.10.2"]},
+    extras_require={"glue": ["boto3", "mypy-boto3-glue"], "md": ["duckdb==0.10.2"]},
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
This PR adds a constraint to setup.py to skip `duckdb` v0.10.3 and avoid issues with view dependency enforcement. This will be fixed in 0.10.4 and above by the `enable_view_dependencies` configuration setting (which is set to false by default).

Related issue: https://github.com/duckdb/duckdb/issues/12191