### PR TITLE
Add DATE to dateadd macro

### DIFF
--- a/dbt/include/duckdb/macros/utils/dateadd.sql
+++ b/dbt/include/duckdb/macros/utils/dateadd.sql
@@ -1,5 +1,5 @@
 {% macro duckdb__dateadd(datepart, interval, from_date_or_timestamp) %}
 
-    date_add({{ from_date_or_timestamp }}, interval ({{ interval }}) {{ datepart }})
+    date_add(DATE {{ from_date_or_timestamp }}, interval ({{ interval }}) {{ datepart }})
 
 {% endmacro %}


### PR DESCRIPTION
Fixes #405 

tl;dr, helps you avoid errors like: 

```
  Binder Error: Could not choose a best candidate function for the function call "+(STRING_LITERAL, INTERVAL)". In order to select one, please add explicit type casts.        Candidate functions:
        +(DATE, INTERVAL) -> TIMESTAMP
        +(TIME, INTERVAL) -> TIME
        +(TIMESTAMP, INTERVAL) -> TIMESTAMP
        +(TIME WITH TIME ZONE, INTERVAL) -> TIME WITH TIME ZONE
        +(TIMESTAMP WITH TIME ZONE, INTERVAL) -> TIMESTAMP WITH TIME ZONE
        +(INTERVAL, INTERVAL) -> INTERVAL

  LINE 1: /* {"app": "dbt", "dbt_version": "1.7.9", "profile_...

```