### PR TITLE
Fixes #412 by not requiring aliases for limit 0 clauses in dbt-duckdb

### DIFF
--- a/dbt/adapters/duckdb/relation.py
+++ b/dbt/adapters/duckdb/relation.py
@@ -13,6 +13,7 @@ from dbt.adapters.contracts.relation import RelationConfig
 
 @dataclass(frozen=True, eq=False, repr=False)
 class DuckDBRelation(BaseRelation):
+    require_alias: bool = False
     external: Optional[str] = None
 
     @classmethod

--- a/tests/functional/adapter/test_empty.py
+++ b/tests/functional/adapter/test_empty.py
@@ -1,0 +1,9 @@
+from dbt.tests.adapter.empty.test_empty import BaseTestEmpty, BaseTestEmptyInlineSourceRef
+
+
+class TestDuckDBEmpty(BaseTestEmpty):
+    pass
+
+
+class TestDuckDBEmptyInlineSourceRef(BaseTestEmptyInlineSourceRef):
+    pass


### PR DESCRIPTION
Added in functional tests for the `--empty` flag while I was in the neighborhood