### PR TITLE
Prep for 1.8.2 release

### DIFF
--- a/dbt/adapters/duckdb/__version__.py
+++ b/dbt/adapters/duckdb/__version__.py
@@ -1,1 +1,1 @@
-version = "1.8.1"
+version = "1.8.2"

--- a/dbt/adapters/duckdb/__version__.py
+++ b/dbt/adapters/duckdb/__version__.py
@@ -1,1 +1,1 @@
-version = "1.8.2"
+version = "1.9.0"

--- a/dbt/adapters/duckdb/__version__.py
+++ b/dbt/adapters/duckdb/__version__.py
@@ -1,1 +1,1 @@
-version = "1.9.0"
+version = "1.8.2"


### PR DESCRIPTION
`dbt-core` is on 1.8.4 and [other adapters](https://docs.getdbt.com/docs/trusted-adapters) are all still using 1.8.x or below versioning. However, since the recent [refactor](https://github.com/dbt-labs/dbt-adapters), `dbt` adapters no longer require staying in pace with `dbt` versioning. From `dbt` team:
> We generally recommend that major version bumps reflect major changes to the adapter and should therefore be reserved. Minor versions should reflect meaningful changes to behavior.

This release includes a major version bump for DuckDB from 0.10.x to 1.0.0 and support for the new DuckDB Secrets Manager, which could be categorized as a "meaningful changes" to the behavior (the feature gap between 0.10.x and 1.0.0 isn't huge - it was mostly bugfixes and stability improvements - and the secrets behavior is an addition that is backward compatible).

I started a discussion on `dbt` community Slack here: [#adapter-ecosystem](https://getdbt.slack.com/archives/C030A0UF5LM).

Update: Bumping **major** version based on discussion with `dbt` team
Update: Sticking with **minor** version for now - once `dbt-core` 1.9 comes out, we're not sure if 1.8.x adapters will remain compatible, and bumping the version again will cause more confusion
Update: OK, after a few more chats with the `dbt` adapters team and evaluating pros and cons, we decided to go with a minor release for now. Let it be so 🪄 