### PR TITLE
Remove deprecated DeltaLake functions

### DIFF
--- a/dbt/adapters/duckdb/plugins/delta.py
+++ b/dbt/adapters/duckdb/plugins/delta.py
@@ -31,10 +31,10 @@ class Plugin(BasePlugin):
         as_of_datetime = source_config.get("as_of_datetime", None)
 
         if as_of_version:
-            dt.load_version(as_of_version)
+            dt.load_as_version(as_of_version)
 
         if as_of_datetime:
-            dt.load_with_datetime(as_of_datetime)
+            dt.load_as_version(as_of_datetime)
 
         df = dt.to_pyarrow_dataset()
 


### PR DESCRIPTION
`load_version` and `load_with_datetime` were replaced with `load_as_version` in `deltalake` 0.19.2.
See: https://github.com/delta-io/delta-rs/pull/2801