### PR TITLE
Fixes to dbt-duckdb to work with DuckDB 1.1.0

### DIFF
--- a/dbt/include/duckdb/macros/adapters.sql
+++ b/dbt/include/duckdb/macros/adapters.sql
@@ -101,7 +101,10 @@ def materialize(df, con):
         if pyarrow_available and isinstance(df, pyarrow.Table):
             # https://github.com/duckdb/duckdb/issues/6584
             import pyarrow.dataset
-    con.execute('create table {{ relation }} as select * from df')
+    tmp_name = '__dbt_python_model_df_' + '{{ relation.identifier }}'
+    con.register(tmp_name, df)
+    con.execute('create table {{ relation }} as select * from ' + tmp_name)
+    con.unregister(tmp_name)
 {% endmacro %}
 
 {% macro duckdb__create_view_as(relation, sql) -%}

--- a/dbt/include/duckdb/macros/utils/datediff.sql
+++ b/dbt/include/duckdb/macros/utils/datediff.sql
@@ -1,3 +1,12 @@
 {% macro duckdb__datediff(first_date, second_date, datepart) -%}
-    date_diff('{{ datepart }}', {{ first_date }}::timestamp, {{ second_date}}::timestamp )
+    {% if datepart == 'week' %}
+            ({{ datediff(first_date, second_date, 'day') }} // 7 + case
+            when date_part('dow', ({{first_date}})::timestamp) <= date_part('dow', ({{second_date}})::timestamp) then
+                case when {{first_date}} <= {{second_date}} then 0 else -1 end
+            else
+                case when {{first_date}} <= {{second_date}} then 1 else 0 end
+        end)
+    {% else %}
+        (date_diff('{{ datepart }}', {{ first_date }}::timestamp, {{ second_date}}::timestamp ))
+    {% endif %}
 {%- endmacro %}


### PR DESCRIPTION
Two fixes for this to work based on my cursory unit testing:

1. We need to explicitly register/unregister the dataframe-ish objects we use inside of the `materialize` function we use for python models, and
2. We need to introduce some custom week-handling logic in the datediff macro to compensate for https://github.com/duckdb/duckdb/pull/13637 and keep the datediff logic for weeks working in the way the rest of the dbt adapters expect it to work.