### PR TITLE
Updates for dbt-duckdb 1.8.4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,7 +73,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
 
     env:
       TOXENV: "unit"
@@ -118,7 +118,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
 
     env:
       TOXENV: "functional"
@@ -163,7 +163,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
 
     env:
       TOXENV: "filebased"
@@ -445,7 +445,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
 
     steps:
       - name: Set up Python ${{ matrix.python-version }}

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,8 +1,8 @@
 # install latest changes in dbt-core + dbt-tests-adapter
-# git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-core&subdirectory=core
-# git+https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-tests-adapter
+git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-core&subdirectory=core
+git+https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-tests-adapter
 
-dbt-tests-adapter==1.9.2
+#dbt-tests-adapter==1.9.2
 
 boto3
 mypy-boto3-glue

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,8 +1,8 @@
 # install latest changes in dbt-core + dbt-tests-adapter
-git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-core&subdirectory=core
-git+https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-tests-adapter
+# git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-core&subdirectory=core
+# git+https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-tests-adapter
 
-#dbt-tests-adapter==1.9.2
+dbt-tests-adapter==1.9.2
 
 boto3
 mypy-boto3-glue


### PR DESCRIPTION
Mostly some cleanup here:

- Moving the tested Python version range from 3.9 through 3.12 (removed 3.8, added 3.12)
- Updated the dbt-tests-adapter and removing a bit where we were doing our own constraint rendering for foreign keys that seems to now be unnecessary