### PR TITLE
Support HTTP secret extra_http_headers

### DIFF
--- a/dbt/adapters/duckdb/secrets.py
+++ b/dbt/adapters/duckdb/secrets.py
@@ -47,7 +47,7 @@ class Secret(dbtClassMixin):
         params.update(params.pop("secret_kwargs", {}))
         params_sql = f",\n{tab}".join(
             [
-                f"{key} '{value}'" if key not in ["type", "provider"] else f"{key} {value}"
+                f"{key} '{value}'" if key not in ["type", "provider", "extra_http_headers"] else f"{key} {value}"
                 for key, value in params.items()
                 if value is not None and key not in ["name", "persistent"]
             ]


### PR DESCRIPTION
To support secrets like:

```sql
CREATE SECRET http (
    TYPE HTTP,
    EXTRA_HTTP_HEADERS MAP {
        'Authorization': 'Bearer sk_test_VePHdqKTYQjKNInc7u56JBrQ'
    }
); 

select unnest(data) as customers 
from read_json('https://api.stripe.com/v1/customers');
```

source:
https://duckdbsnippets.com/snippets/184/query-an-authenticated-api-endpoint