### PR TITLE
Remove mention of outdated MotherDuck constraints in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,8 @@ or the Python API.
 
 MotherDuck databases generally work the same way as local DuckDB databases from the perspective of dbt, but
 there are a [few differences to be aware of](https://motherduck.com/docs/architecture-and-capabilities#considerations-and-limitations):
-1. Currently, MotherDuck _requires_ a specific version of DuckDB, often the latest, as specified in [MotherDuck's documentation](https://motherduck.com/docs/intro/#getting-started)
+1. MotherDuck is compatible with client DuckDB versions 0.10.2 and older.
 1. MotherDuck preloads a set of the most common DuckDB extensions for you, but does not support loading custom extensions or user-defined functions.
-1. A small subset of advanced SQL features are currently unsupported; the only impact of this on the dbt adapter is that the [dbt.listagg](https://docs.getdbt.com/reference/dbt-jinja-functions/cross-database-macros#listagg) macro and foreign-key constraints will work against a local DuckDB database, but will not work against a MotherDuck database.
 
 #### DuckDB Extensions, Settings, and Filesystems
 


### PR DESCRIPTION
MotherDuck is now backwards-compatible with old client DuckDB versions. Also, foreign keys and macros are supported. Therefore, two of the constraints mentioned when using dbt with MotherDuck can be removed from the readme.