### PR TITLE
Add safety check for node in graph

### DIFF
--- a/dbt/include/duckdb/macros/utils/upstream.sql
+++ b/dbt/include/duckdb/macros/utils/upstream.sql
@@ -3,6 +3,7 @@
 {% set upstream_nodes = {} %}
 {% set upstream_schemas = {} %}
 {% for node in selected_resources %}
+  {% if node not in graph['nodes'] %}{% continue %}{% endif %}
   {% for upstream_node in graph['nodes'][node]['depends_on']['nodes'] %}
     {% if upstream_node not in upstream_nodes and upstream_node not in selected_resources %}
       {% do upstream_nodes.update({upstream_node: None}) %}


### PR DESCRIPTION
With dbt's unit-test feature, dbt may not populate the graph when running `dbt test -s model_to_test`. This will result in an error in `register_upstream_external_models`:

```
on-run-start failed, error:
 'dict object' has no attribute 'unit_test.project_name.model_name.test_name'
```

This change checks if a node is present before looking for its dependencies.