### PR TITLE
Add unique UUID to temp table name

### DIFF
--- a/dbt/adapters/duckdb/impl.py
+++ b/dbt/adapters/duckdb/impl.py
@@ -52,7 +52,7 @@ class DuckDBAdapter(SQLAdapter):
 
     # can be overridden via the model config metadata
     _temp_schema_name = DEFAULT_TEMP_SCHEMA_NAME
-    _temp_schema_unique_id = defaultdict(uuid4)
+    _temp_schema_model_uuid = defaultdict(uuid4)
 
     @classmethod
     def date_function(cls) -> str:
@@ -289,12 +289,12 @@ class DuckDBAdapter(SQLAdapter):
         currently doesn't support remote temporary tables. Instead we use a regular
         table that is dropped at the end of the incremental macro or post-model hook.
         """
-        # Add a unique identifier for this Python session to enable running the incremental model concurrently
-        unique_id = self._temp_schema_unique_id[model.identifier]
+        # Add a unique identifier for this model (scoped per dbt run)
+        uuid = self._temp_schema_model_uuid[model.identifier]
         return Path(
             schema=self._temp_schema_name,
             database=model.database,
-            identifier=f"{model.identifier}__{unique_id}",
+            identifier=f"{model.identifier}__{uuid}",
         )
 
     def post_model_hook(self, config: Any, context: Any) -> None:

--- a/dbt/adapters/duckdb/impl.py
+++ b/dbt/adapters/duckdb/impl.py
@@ -290,11 +290,11 @@ class DuckDBAdapter(SQLAdapter):
         table that is dropped at the end of the incremental macro or post-model hook.
         """
         # Add a unique identifier for this model (scoped per dbt run)
-        uuid = self._temp_schema_model_uuid[model.identifier]
+        _uuid = self._temp_schema_model_uuid[model.identifier]
         return Path(
             schema=self._temp_schema_name,
             database=model.database,
-            identifier=f"{model.identifier}__{uuid}",
+            identifier=f"{model.identifier}__{_uuid}",
         )
 
     def post_model_hook(self, config: Any, context: Any) -> None:

--- a/dbt/adapters/duckdb/impl.py
+++ b/dbt/adapters/duckdb/impl.py
@@ -1,11 +1,12 @@
-from collections import defaultdict
 import os
+from collections import defaultdict
 from typing import Any
 from typing import List
 from typing import Optional
 from typing import Sequence
 from typing import TYPE_CHECKING
-from uuid import UUID, uuid4
+from uuid import UUID
+from uuid import uuid4
 
 from dbt_common.contracts.constraints import ColumnLevelConstraint
 from dbt_common.contracts.constraints import ConstraintType

--- a/dbt/adapters/duckdb/impl.py
+++ b/dbt/adapters/duckdb/impl.py
@@ -5,7 +5,6 @@ from typing import List
 from typing import Optional
 from typing import Sequence
 from typing import TYPE_CHECKING
-from uuid import UUID
 from uuid import uuid4
 
 from dbt_common.contracts.constraints import ColumnLevelConstraint

--- a/dbt/adapters/duckdb/impl.py
+++ b/dbt/adapters/duckdb/impl.py
@@ -53,7 +53,7 @@ class DuckDBAdapter(SQLAdapter):
 
     # can be overridden via the model config metadata
     _temp_schema_name = DEFAULT_TEMP_SCHEMA_NAME
-    _temp_schema_model_uuid: dict[str, UUID] = defaultdict(lambda: str(uuid4()).split("-")[-1])
+    _temp_schema_model_uuid: dict[str, str] = defaultdict(lambda: str(uuid4()).split("-")[-1])
 
     @classmethod
     def date_function(cls) -> str:

--- a/dbt/adapters/duckdb/impl.py
+++ b/dbt/adapters/duckdb/impl.py
@@ -5,7 +5,7 @@ from typing import List
 from typing import Optional
 from typing import Sequence
 from typing import TYPE_CHECKING
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 from dbt_common.contracts.constraints import ColumnLevelConstraint
 from dbt_common.contracts.constraints import ConstraintType
@@ -52,7 +52,7 @@ class DuckDBAdapter(SQLAdapter):
 
     # can be overridden via the model config metadata
     _temp_schema_name = DEFAULT_TEMP_SCHEMA_NAME
-    _temp_schema_model_uuid = defaultdict(uuid4)
+    _temp_schema_model_uuid: dict[str, UUID] = defaultdict(uuid4)
 
     @classmethod
     def date_function(cls) -> str:

--- a/dbt/adapters/duckdb/impl.py
+++ b/dbt/adapters/duckdb/impl.py
@@ -53,7 +53,7 @@ class DuckDBAdapter(SQLAdapter):
 
     # can be overridden via the model config metadata
     _temp_schema_name = DEFAULT_TEMP_SCHEMA_NAME
-    _temp_schema_model_uuid: dict[str, UUID] = defaultdict(uuid4)
+    _temp_schema_model_uuid: dict[str, UUID] = defaultdict(lambda: str(uuid4()).split("-")[-1])
 
     @classmethod
     def date_function(cls) -> str:


### PR DESCRIPTION
A user ran into the issue that they have multiple `dbt` projects running in parallel, but because the temp table has the same name, they may run into collisions. This PR adds a unique identifier to the temp table.