### PR TITLE
Fix out of date README comment about version support for dbt-core and duckdb

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,8 @@ This project is hosted on PyPI, so you should be able to install it and the nece
 
 `pip3 install dbt-duckdb`
 
-The latest supported version targets `dbt-core` 1.7.x and `duckdb` version 0.10.x, but we work hard to ensure that newer
-versions of DuckDB will continue to work with the adapter as they are released. If you would like to use our new (and experimental!)
-support for persisting the tables that DuckDB creates to the [AWS Glue Catalog](https://aws.amazon.com/glue/), you should install
-`dbt-duckdb[glue]` in order to get the AWS dependencies as well.
+The latest supported version targets `dbt-core` versions >= 1.8.x and `duckdb` version 1.1.x, but we work hard to ensure that newer
+versions of DuckDB will continue to work with the adapter as they are released.
 
 ### Configuring Your Profile
 


### PR DESCRIPTION
Got a ping about this via https://github.com/duckdb/dbt-duckdb/discussions/484 and trying to make it right