### PR TITLE
Drop Python 3.8 support, add 3.12

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,10 +13,10 @@ classifier =
     Operating System :: Microsoft :: Windows
     Operating System :: MacOS :: MacOS X
     Operating System :: POSIX :: Linux
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
 keywords =
     setup
     distutils
@@ -28,7 +28,7 @@ install_requires=
     duckdb>=1.0.0
     # add dbt-core to ensure backwards compatibility of installation, this is not a functional dependency
     dbt-core>=1.8.0
-python_requires = >=3.8
+python_requires = >=3.9
 include_package_data = True
 packages = find_namespace:
 


### PR DESCRIPTION
Python 3.8 just passed EOL: https://devguide.python.org/versions/
Follow up on #488 