### PR TITLE
Make keep_open: true the default setting for dbt-duckdb going forward

### DIFF
--- a/dbt/adapters/duckdb/credentials.py
+++ b/dbt/adapters/duckdb/credentials.py
@@ -145,9 +145,7 @@ class DuckDBCredentials(Credentials):
     disable_transactions: bool = False
 
     # Whether to keep the DuckDB connection open between invocations of dbt
-    # (we do this automatically for in-memory or MD connections, but not for
-    # local DuckDB files, but this is a way to override that behavior)
-    keep_open: bool = False
+    keep_open: bool = True
 
     # A list of paths to Python modules that should be loaded into the
     # running Python environment when dbt is invoked; this is useful for

--- a/tests/functional/adapter/test_community_extensions.py
+++ b/tests/functional/adapter/test_community_extensions.py
@@ -7,7 +7,7 @@ from dbt.tests.util import (
     run_dbt,
 )
 
-@pytest.mark.skip_profile("nightly", reason="Cannot install community extensions for nightly release")
+@pytest.mark.skip_profile("buenavista", "nightly", reason="Cannot install community extensions for nightly release")
 class BaseCommunityExtensions:
 
     @pytest.fixture(scope="class")

--- a/tests/functional/plugins/test_delta.py
+++ b/tests/functional/plugins/test_delta.py
@@ -97,7 +97,6 @@ class TestPlugins:
                     "dev": {
                         "type": "duckdb",
                         "path": dbt_profile_target.get("path", ":memory:"),
-                        "keep_open": False,
                         "plugins": plugins,
                     }
                 },

--- a/tests/functional/plugins/test_delta.py
+++ b/tests/functional/plugins/test_delta.py
@@ -97,6 +97,7 @@ class TestPlugins:
                     "dev": {
                         "type": "duckdb",
                         "path": dbt_profile_target.get("path", ":memory:"),
+                        "keep_open": False,
                         "plugins": plugins,
                     }
                 },


### PR DESCRIPTION
Recent versions of DuckDB (>= 1.13) seem to perform better/more reliably when we leave the connection to the DuckDB file open for the entire DuckDB run vs. the old behavior of having different threads open/close the file in rapid succession, so moving to a model where we generally take ownership of the DuckDB file for the length of any dbt run unless explictly told not to in the profiles.yml.