### PR TITLE
[Fix] External materialization to S3 does not work if table is empty

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -123,6 +123,9 @@ jobs:
     env:
       TOXENV: "functional"
       PYTEST_ADDOPTS: "-v --color=yes --csv functional_results.csv"
+      S3_MD_ORG_KEY: ${{ secrets.S3_MD_ORG_KEY }}
+      S3_MD_ORG_REGION: ${{ secrets.S3_MD_ORG_REGION }}
+      S3_MD_ORG_SECRET: ${{ secrets.S3_MD_ORG_SECRET }}
 
     steps:
       - name: Check out the repository
@@ -168,6 +171,9 @@ jobs:
     env:
       TOXENV: "filebased"
       PYTEST_ADDOPTS: "-v --color=yes --csv filebased_results.csv"
+      S3_MD_ORG_KEY: ${{ secrets.S3_MD_ORG_KEY }}
+      S3_MD_ORG_REGION: ${{ secrets.S3_MD_ORG_REGION }}
+      S3_MD_ORG_SECRET: ${{ secrets.S3_MD_ORG_SECRET }}
 
     steps:
       - name: Check out the repository
@@ -228,6 +234,9 @@ jobs:
       TOXENV: "md"
       MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN_10 }}
       PYTEST_ADDOPTS: "-v --color=yes --csv motherduck_results.csv"
+      S3_MD_ORG_KEY: ${{ secrets.S3_MD_ORG_KEY }}
+      S3_MD_ORG_REGION: ${{ secrets.S3_MD_ORG_REGION }}
+      S3_MD_ORG_SECRET: ${{ secrets.S3_MD_ORG_SECRET }}
 
     steps:
       - name: Check out the repository

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -35,6 +35,9 @@ jobs:
     env:
       TOXENV: "nightly"
       PYTEST_ADDOPTS: "-v --color=yes --csv unit_results.csv"
+      S3_MD_ORG_KEY: ${{ secrets.S3_MD_ORG_KEY }}
+      S3_MD_ORG_REGION: ${{ secrets.S3_MD_ORG_REGION }}
+      S3_MD_ORG_SECRET: ${{ secrets.S3_MD_ORG_SECRET }}
 
     steps:
       - name: Check out the repository


### PR DESCRIPTION
Workaround for https://github.com/duckdb/dbt-duckdb/issues/503 (need to look into fix in `duckdb` for writing empty tables to S3)

It consists of inserting `NULL` values (if the table is empty), writing those to S3, and then creating a view that filters those `NULL` values