### PR TITLE
skip s3 tests if the secrets are not available

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,3 +103,15 @@ def skip_by_profile_type(profile_type, request):
 def test_data_path():
     test_dir = os.path.dirname(os.path.abspath(__file__))
     return os.path.join(test_dir, "data")
+
+
+def pytest_collection_modifyitems(config, items):
+    # Skip the S3 tests if the secrets are not available
+    if not (
+        os.getenv("S3_MD_ORG_KEY") and os.getenv("S3_MD_ORG_REGION") and os.getenv("S3_MD_ORG_SECRET")
+    ):
+        skip_s3 = pytest.mark.skip(reason="need S3 credentials to run this test")
+        for item in items:
+            item.add_marker(pytest.mark.timeout(7200))  # 2 hours
+            if "with_s3_creds" in item.keywords:
+                item.add_marker(skip_s3)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,6 +112,5 @@ def pytest_collection_modifyitems(config, items):
     ):
         skip_s3 = pytest.mark.skip(reason="need S3 credentials to run this test")
         for item in items:
-            item.add_marker(pytest.mark.timeout(7200))  # 2 hours
             if "with_s3_creds" in item.keywords:
                 item.add_marker(skip_s3)

--- a/tests/functional/adapter/test_external.py
+++ b/tests/functional/adapter/test_external.py
@@ -202,6 +202,7 @@ class TestExternalMaterializationsLocalEmpty(BaseExternalMaterializations):
         return True
 
 
+@pytest.mark.with_s3_creds
 @pytest.mark.skip_profile("buenavista")
 class TestExternalMaterializationsS3(BaseExternalMaterializations):
     @pytest.fixture(scope="class")
@@ -213,6 +214,7 @@ class TestExternalMaterializationsS3(BaseExternalMaterializations):
         return False
 
 
+@pytest.mark.with_s3_creds
 @pytest.mark.skip_profile("buenavista")
 class TestExternalMaterializationsS3Empty(BaseExternalMaterializations):
     @pytest.fixture(scope="class")


### PR DESCRIPTION
I noticed that PR builds from non maintainers (e.g. dependabot) currently fail without secrets access
this PR adds a marker and skips them if s3 secrets are not available