### PR TITLE
Vibe-claudeing a duckdbt CLI

### DIFF
--- a/dbt/adapters/duckdb/cli.py
+++ b/dbt/adapters/duckdb/cli.py
@@ -3,10 +3,12 @@ import cmd
 import os
 import shlex
 import sys
-from typing import List, Optional
+from typing import List
+from typing import Optional
 
 from dbt.adapters.duckdb.connections import DuckDBConnectionManager
-from dbt.cli.main import dbtRunner, dbtRunnerResult
+from dbt.cli.main import dbtRunner
+from dbt.cli.main import dbtRunnerResult
 
 
 class DuckdbtShell(cmd.Cmd):
@@ -21,11 +23,13 @@ class DuckdbtShell(cmd.Cmd):
         # Run debug to test out the connection on startup
         result = self.dbt.invoke(["debug"])
         if result.success:
-            cursor = DuckDBConnectionManager._ENV.handle().cursor()
-            cursor.execute("CALL start_ui()")
-            cursor.close()
+            if DuckDBConnectionManager._ENV:
+                env = DuckDBConnectionManager._ENV
+                cursor = env.handle().cursor()
+                print("Launching DuckDB UI...")
+                cursor.execute("CALL start_ui()")
+                cursor.close()
         else:
-            print("Exception running dbt debug...", result.exception)
             sys.exit(1)
 
         project_name = os.path.basename(os.getcwd())
@@ -34,14 +38,14 @@ class DuckdbtShell(cmd.Cmd):
     def _run_dbt_command(self, command: List[str]) -> None:
         """Run a dbt command with the runner"""
         cmd_args = []
-        
+
         # Add profile if specified
         if self.profile:
             cmd_args.extend(["--profile", self.profile])
-            
+
         # Add the user command
         cmd_args.extend(command)
-        
+
         try:
             result: dbtRunnerResult = self.dbt.invoke(cmd_args)
             if result.success:
@@ -61,7 +65,7 @@ class DuckdbtShell(cmd.Cmd):
         """Test models: test [options]"""
         args = ["test"] + shlex.split(arg)
         self._run_dbt_command(args)
-        
+
     def do_build(self, arg):
         """Build models: build [options]"""
         args = ["build"] + shlex.split(arg)
@@ -71,32 +75,32 @@ class DuckdbtShell(cmd.Cmd):
         """Load seed files: seed [options]"""
         args = ["seed"] + shlex.split(arg)
         self._run_dbt_command(args)
-        
+
     def do_snapshot(self, arg):
         """Run snapshots: snapshot [options]"""
         args = ["snapshot"] + shlex.split(arg)
         self._run_dbt_command(args)
-        
+
     def do_compile(self, arg):
         """Compile models: compile [options]"""
         args = ["compile"] + shlex.split(arg)
         self._run_dbt_command(args)
-        
+
     def do_debug(self, arg):
         """Debug connection: debug [options]"""
         args = ["debug"] + shlex.split(arg)
         self._run_dbt_command(args)
-        
+
     def do_deps(self, arg):
         """Install dependencies: deps [options]"""
         args = ["deps"] + shlex.split(arg)
         self._run_dbt_command(args)
-        
+
     def do_list(self, arg):
         """List resources: list [options]"""
         args = ["list"] + shlex.split(arg)
         self._run_dbt_command(args)
-        
+
     def do_parse(self, arg):
         """Parse project: parse [options]"""
         args = ["parse"] + shlex.split(arg)
@@ -106,16 +110,16 @@ class DuckdbtShell(cmd.Cmd):
         """Exit the shell"""
         print("Goodbye!")
         return True
-        
+
     def do_quit(self, arg):
         """Exit the shell"""
         return self.do_exit(arg)
-        
+
     def do_EOF(self, arg):
         """Exit on Ctrl-D"""
         print()  # Print newline
         return self.do_exit(arg)
-        
+
     def emptyline(self):
         """Do nothing on empty line"""
         pass
@@ -123,15 +127,15 @@ class DuckdbtShell(cmd.Cmd):
 
 def main():
     import argparse
-    
+
     parser = argparse.ArgumentParser(description="duckdbt interactive shell")
     parser.add_argument(
-        "--profile", 
+        "--profile",
         help="Name of the dbt profile to use",
     )
-    
+
     args = parser.parse_args()
-    
+
     shell = DuckdbtShell(
         profile=args.profile,
     )

--- a/dbt/adapters/duckdb/cli.py
+++ b/dbt/adapters/duckdb/cli.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python
+import cmd
+import os
+import shlex
+import sys
+from typing import List, Optional
+
+from dbt.adapters.duckdb.connections import DuckDBConnectionManager
+from dbt.cli.main import dbtRunner, dbtRunnerResult
+
+
+class DuckdbtShell(cmd.Cmd):
+    intro = "Welcome to the duckdbt shell. Type help or ? to list commands."
+    prompt = "duckdbt> "
+
+    def __init__(self, profile: Optional[str] = None):
+        super().__init__()
+        self.dbt = dbtRunner()
+        self.profile = profile
+
+        # Run debug to test out the connection on startup
+        result = self.dbt.invoke(["debug"])
+        if result.success:
+            cursor = DuckDBConnectionManager._ENV.handle().cursor()
+            cursor.execute("CALL start_ui()")
+            cursor.close()
+        else:
+            print("Exception running dbt debug...", result.exception)
+            sys.exit(1)
+
+        project_name = os.path.basename(os.getcwd())
+        self.prompt = f"duckdbt ({project_name})> "
+
+    def _run_dbt_command(self, command: List[str]) -> None:
+        """Run a dbt command with the runner"""
+        cmd_args = []
+        
+        # Add profile if specified
+        if self.profile:
+            cmd_args.extend(["--profile", self.profile])
+            
+        # Add the user command
+        cmd_args.extend(command)
+        
+        try:
+            result: dbtRunnerResult = self.dbt.invoke(cmd_args)
+            if result.success:
+                return
+            else:
+                print("Command failed: ", result.exception)
+                return
+        except Exception as e:
+            print(f"Error: {str(e)}")
+
+    def do_run(self, arg):
+        """Run models: run [options]"""
+        args = ["run"] + shlex.split(arg)
+        self._run_dbt_command(args)
+
+    def do_test(self, arg):
+        """Test models: test [options]"""
+        args = ["test"] + shlex.split(arg)
+        self._run_dbt_command(args)
+        
+    def do_build(self, arg):
+        """Build models: build [options]"""
+        args = ["build"] + shlex.split(arg)
+        self._run_dbt_command(args)
+
+    def do_seed(self, arg):
+        """Load seed files: seed [options]"""
+        args = ["seed"] + shlex.split(arg)
+        self._run_dbt_command(args)
+        
+    def do_snapshot(self, arg):
+        """Run snapshots: snapshot [options]"""
+        args = ["snapshot"] + shlex.split(arg)
+        self._run_dbt_command(args)
+        
+    def do_compile(self, arg):
+        """Compile models: compile [options]"""
+        args = ["compile"] + shlex.split(arg)
+        self._run_dbt_command(args)
+        
+    def do_debug(self, arg):
+        """Debug connection: debug [options]"""
+        args = ["debug"] + shlex.split(arg)
+        self._run_dbt_command(args)
+        
+    def do_deps(self, arg):
+        """Install dependencies: deps [options]"""
+        args = ["deps"] + shlex.split(arg)
+        self._run_dbt_command(args)
+        
+    def do_list(self, arg):
+        """List resources: list [options]"""
+        args = ["list"] + shlex.split(arg)
+        self._run_dbt_command(args)
+        
+    def do_parse(self, arg):
+        """Parse project: parse [options]"""
+        args = ["parse"] + shlex.split(arg)
+        self._run_dbt_command(args)
+
+    def do_exit(self, arg):
+        """Exit the shell"""
+        print("Goodbye!")
+        return True
+        
+    def do_quit(self, arg):
+        """Exit the shell"""
+        return self.do_exit(arg)
+        
+    def do_EOF(self, arg):
+        """Exit on Ctrl-D"""
+        print()  # Print newline
+        return self.do_exit(arg)
+        
+    def emptyline(self):
+        """Do nothing on empty line"""
+        pass
+
+
+def main():
+    import argparse
+    
+    parser = argparse.ArgumentParser(description="duckdbt interactive shell")
+    parser.add_argument(
+        "--profile", 
+        help="Name of the dbt profile to use",
+    )
+    
+    args = parser.parse_args()
+    
+    shell = DuckdbtShell(
+        profile=args.profile,
+    )
+    shell.cmdloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,10 @@ include =
     dbt
     dbt.*
 
+[options.entry_points]
+console_scripts =
+    duckdbt = dbt.adapters.duckdb.cli:main
+
 [build-system]
 requires = ["setuptools >= 61.2", "pbr>=1.9"]
 


### PR DESCRIPTION
Been playing with the new DuckDB UI stuff and Claude Code a lot this week and cooked up something simple that does what I've always wanted to be able to do with dbt and DuckDB: run the dbt-duckdb process in a shell process where I could simultaneously query the DuckDB instance via a UI and run my dbt-duckdb models in a high-fidelity way, with all of the python model execution and all of the other great stuff we've built in this project over the last few years.

The idea is to create a `cli.py` and a new `duckdbt` shell command that uses the [dbtRunner](https://docs.getdbt.com/reference/programmatic-invocations) construct to load up dbt, parse all of the models in a project using a given profile, and let you run command invocations in the CLI while simultaneously launching the DuckDB UI via a `CALL start_ui()` call against the instance of DuckDB that gets loaded and configured when `dbt debug` is called.