### PR TITLE
Add support for scoped secrets/credentials by storage prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,31 @@ default:
   target: dev
 ```
 
+#### Scoped credentials by storage prefix
+
+Secrets can be scoped, such that different storage path can use different credentials.
+
+```
+default:
+  outputs:
+    dev:
+      type: duckdb
+      path: /tmp/dbt.duckdb
+      extensions:
+        - httpfs
+        - parquet
+      secrets:
+        - type: s3
+          provider: credential_chain
+          scope: [ "s3://bucket-in-eu-region", "s3://bucket-2-in-eu-region" ]
+          region: "eu-central-1"
+        - type: s3
+          region: us-west-2
+          scope: "s3://bucket-in-us-region"
+```
+
+When fetching a secret for a path, the secret scopes are compared to the path, returning the matching secret for the path. In the case of multiple matching secrets, the longest prefix is chosen.
+
 #### Attaching Additional Databases
 
 DuckDB version `0.7.0` added support for [attaching additional databases](https://duckdb.org/docs/sql/statements/attach.html) to your dbt-duckdb run so that you can read

--- a/dbt/adapters/duckdb/secrets.py
+++ b/dbt/adapters/duckdb/secrets.py
@@ -1,7 +1,9 @@
 from dataclasses import dataclass
 from typing import Any
 from typing import Dict
+from typing import List
 from typing import Optional
+from typing import Union
 
 from dbt_common.dataclass_schema import dbtClassMixin
 
@@ -15,7 +17,7 @@ class Secret(dbtClassMixin):
     persistent: Optional[bool] = False
     name: Optional[str] = None
     provider: Optional[str] = None
-    scope: Optional[str] = None
+    scope: Optional[Union[str, List[str]]] = None
     secret_kwargs: Optional[Dict[str, Any]] = None
 
     @classmethod
@@ -25,7 +27,7 @@ class Secret(dbtClassMixin):
         persistent: Optional[bool] = None,
         name: Optional[str] = None,
         provider: Optional[str] = None,
-        scope: Optional[str] = None,
+        scope: Optional[Union[str, List[str]]] = None,
         **kwargs,
     ):
         # Create and return Secret
@@ -45,14 +47,36 @@ class Secret(dbtClassMixin):
         tab = "    "
         params = self.to_dict(omit_none=True)
         params.update(params.pop("secret_kwargs", {}))
-        params_sql = f",\n{tab}".join(
-            [
+
+        scope_value: Optional[List[str]] = None
+        raw_scope = params.get("scope")
+        if isinstance(raw_scope, str):
+            scope_value = [raw_scope]
+        elif isinstance(raw_scope, list):
+            scope_value = raw_scope
+
+        if scope_value is not None:
+            params.pop("scope", None)
+            params_sql: List[str] = []
+            for key, value in params.items():
+                if value is not None and key not in ["name", "persistent"]:
+                    if key not in ["type", "provider", "extra_http_headers"]:
+                        params_sql.append(f"{key} '{value}'")
+                    else:
+                        params_sql.append(f"{key} {value}")
+            for s in scope_value:
+                params_sql.append(f"scope '{s}'")
+
+            params_sql_str = f",\n{tab}".join(params_sql)
+        else:
+            params_sql_list = [
                 f"{key} '{value}'"
                 if key not in ["type", "provider", "extra_http_headers"]
                 else f"{key} {value}"
                 for key, value in params.items()
                 if value is not None and key not in ["name", "persistent"]
             ]
-        )
-        sql = f"""CREATE{or_replace}{persistent} SECRET{name} (\n{tab}{params_sql}\n)"""
+            params_sql_str = f",\n{tab}".join(params_sql_list)
+
+        sql = f"""CREATE{or_replace}{persistent} SECRET{name} (\n{tab}{params_sql_str}\n)"""
         return sql


### PR DESCRIPTION
This PR introduces small changes to support `scope` in duckdb secrets created through a duckdb profile eg) `profile.yml`.

Context: I wanted to query data in different s3 buckets, they have different regions and require different credentials. This was somewhat supported before, however multiple "scopes" per secret where not supported. It was is possible with duckdb secrets manager, but I had to create the secrets manually.

This PR to create the secrets through a duckdb profile. For the below example, the first secret will be used anytime the first two buckets path is queried and the second secret will be used for the other.

```yaml
default:
  outputs:
    dev:
      type: duckdb
      path: /tmp/dbt.duckdb
      extensions:
        - httpfs
        - parquet
      secrets:
        - type: s3
          provider: credential_chain
          scope: [ "s3://bucket-in-eu-region", "s3://bucket-2-in-eu-region" ]
          region: "eu-central-1"
        - type: s3
          region: us-west-2
          scope: "s3://bucket-in-us-region"
```

Reference: [https://duckdb.org/docs/stable/configuration/secrets_manager.html](https://duckdb.org/docs/stable/configuration/secrets_manager.html)