### PR TITLE
MotherDuck supports transactions now, so we don't need to disable them by default anymore

### DIFF
--- a/dbt/adapters/duckdb/credentials.py
+++ b/dbt/adapters/duckdb/credentials.py
@@ -228,11 +228,7 @@ class DuckDBCredentials(Credentials):
             parsed = urlparse(path)
             base_file = os.path.basename(parsed.path)
             path_db = os.path.splitext(base_file)[0]
-            # For MotherDuck, turn on disable_transactions unless
-            # it's explicitly set already by the user
             if cls._is_motherduck(parsed.scheme):
-                if "disable_transactions" not in data:
-                    data["disable_transactions"] = True
                 if path_db == "":
                     path_db = "my_db"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ glue =
     boto3
     mypy-boto3-glue
 md =
-    duckdb==1.1.1
+    duckdb==1.2.1
 
 [files]
 packages =

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,7 +81,6 @@ def dbt_profile_target(profile_type, bv_server_process, tmpdir_factory):
             profile["token"] = os.environ.get(TEST_MOTHERDUCK_TOKEN)
         else:
             profile["token"] = os.environ.get(MOTHERDUCK_TOKEN, os.environ.get(MOTHERDUCK_TOKEN.lower()))
-        profile["disable_transactions"] = True
         profile["path"] = "md:test"
     elif profile_type in ["memory", "nightly"]:
         pass  # use the default path-less profile


### PR DESCRIPTION
This probably fixes a whole host of issues, but most directly #533 and #532 