### PR TITLE
Add SQLGlot Plugin to transpile from any SQL dialect into DuckDb

### DIFF
--- a/dbt/adapters/duckdb/environments/__init__.py
+++ b/dbt/adapters/duckdb/environments/__init__.py
@@ -229,6 +229,9 @@ class Environment(abc.ABC):
         for df_name, df in registered_df.items():
             cursor.register(df_name, df)
 
+        if "sqlglot" in plugins:
+            cursor = plugins["sqlglot"].cursor(cursor)
+
         if creds.retries and creds.retries.query_attempts:
             cursor = RetryableCursor(
                 cursor, creds.retries.query_attempts, creds.retries.retryable_exceptions

--- a/dbt/adapters/duckdb/plugins/sqlglot.py
+++ b/dbt/adapters/duckdb/plugins/sqlglot.py
@@ -1,0 +1,35 @@
+from typing import Any
+from typing import Dict
+
+import sqlglot
+from dbt_common.exceptions import DbtRuntimeError
+
+from . import BasePlugin
+
+
+class TranspiledCursor:
+    def __init__(self, cursor, trans_from: str):
+        self.trans_from = trans_from
+        self._cursor = cursor
+
+    # forward along all non-execute() methods/attribute look-ups
+    def __getattr__(self, name):
+        return getattr(self._cursor, name)
+
+    def execute(self, sql, bindings=None):
+        sql = sqlglot.transpile(sql, read=self.trans_from, write="duckdb").pop()
+        try:
+            if bindings is None:
+                return self._cursor.execute(sql)
+            else:
+                return self._cursor.execute(sql, bindings)
+        except RuntimeError as e:
+            raise DbtRuntimeError(str(e))
+
+
+class Plugin(BasePlugin):
+    def initialize(self, plugin_config: Dict[str, Any]):
+        self.trans_from = plugin_config.get("trans_from", "duckdb")
+
+    def cursor(self, cursor):
+        return TranspiledCursor(cursor, self.trans_from)

--- a/tests/functional/plugins/test_sqlglot.py
+++ b/tests/functional/plugins/test_sqlglot.py
@@ -1,0 +1,54 @@
+import pytest
+
+from dbt.adapters.duckdb.plugins.postgres import Plugin
+from dbt.tests.fixtures.project import TestProjInfo
+from dbt.tests.util import check_relations_equal, run_dbt
+
+
+class TestSqlglotPlugin:
+    @pytest.fixture(scope="class")
+    def profiles_config_update(self, dbt_profile_target):
+        return {
+            "test": {
+                "outputs": {
+                    "dev": {
+                        "type": "duckdb",
+                        "path": dbt_profile_target.get("path", ":memory:"),
+                        "plugins": [
+                            {"module": "sqlglot", "config": {"trans_from": "postgres"}}
+                        ],
+                    }
+                },
+                "target": "dev",
+            }
+        }
+    
+
+    
+    def test_sqlglot_plugin(self, project: TestProjInfo):
+        res = project.run_sql("select to_date('2024-12-31', 'YYYY-MM-DD')", fetch="one")
+
+
+
+class TestSqlglotPluginMySql:
+    @pytest.fixture(scope="class")
+    def profiles_config_update(self, dbt_profile_target):
+        return {
+            "test": {
+                "outputs": {
+                    "dev": {
+                        "type": "duckdb",
+                        "path": dbt_profile_target.get("path", ":memory:"),
+                        "plugins": [
+                            {"module": "sqlglot", "config": {"trans_from": "mysql"}}
+                        ],
+                    }
+                },
+                "target": "dev",
+            }
+        }
+    
+
+    
+    def test_sqlglot_plugin(self, project: TestProjInfo):
+        res = project.run_sql("select str_to_date('2024-12-31', '%Y-%m-%d')", fetch="one")


### PR DESCRIPTION
One of the most common use case for DuckDb is to run SQL tests locally. [SQLMesh](https://github.com/TobikoData/sqlmesh) supports this natively with [SQLGlot](https://github.com/tobymao/sqlglot), but no alternative exists for dbt workflow. There's global macros but they don't cover many use cases. In my case it's to transpile `to_date` in postgres into `strptime` in duckdb. This plugin facilitates that by intercepting the original compiled sql (either in redshift, postgres, or mysql), and transpiling them into duckdb syntax.