### PR TITLE
Apply project quoting setting to add/remove columns

### DIFF
--- a/dbt/include/duckdb/macros/columns.sql
+++ b/dbt/include/duckdb/macros/columns.sql
@@ -4,7 +4,7 @@
     {% for column in add_columns %}
       {% set sql -%}
          alter {{ relation.type }} {{ relation }} add column
-           {{ column.name }} {{ column.data_type }}
+           {{ api.Relation.create(identifier=column.name) }} {{ column.data_type }}
       {%- endset -%}
       {% do run_query(sql) %}
     {% endfor %}
@@ -14,7 +14,7 @@
     {% for column in remove_columns %}
       {% set sql -%}
         alter {{ relation.type }} {{ relation }} drop column
-          {{ column.name }}
+          {{ api.Relation.create(identifier=column.name) }}
       {%- endset -%}
       {% do run_query(sql) %}
     {% endfor %}

--- a/tests/functional/adapter/test_incremental.py
+++ b/tests/functional/adapter/test_incremental.py
@@ -6,8 +6,11 @@ from dbt.tests.adapter.incremental.test_incremental_predicates import (
 )
 from dbt.tests.adapter.incremental.test_incremental_on_schema_change import (
     BaseIncrementalOnSchemaChange,
+    BaseIncrementalOnSchemaChangeSetup
 )
 from dbt.artifacts.schemas.results import RunStatus
+from dbt.tests.util import run_dbt
+import pytest
 
 
 class TestIncrementalUniqueKey(BaseIncrementalUniqueKey):
@@ -29,5 +32,113 @@ class TestIncrementalPredicates(BaseIncrementalPredicates):
     pass
 
 
-class TestIncrementalOnSchemaChange(BaseIncrementalOnSchemaChange):
+class TestIncrementalOnSchemaChange(BaseIncrementalOnSchemaChange):     
     pass
+    
+
+models__incremental_append_new_columns_with_space = """
+{{
+    config(
+        materialized='incremental',
+        unique_key='id',
+        on_schema_change='append_new_columns'
+    )
+}}
+
+{% set string_type = dbt.type_string() %}
+
+WITH source_data AS (SELECT * FROM {{ ref('model_a') }} )
+
+{% if is_incremental()  %}
+
+SELECT id,
+       cast(field1 as {{string_type}}) as field1,
+       cast(field2 as {{string_type}}) as field2,
+       cast(field3 as {{string_type}}) as "field 3",
+       cast(field4 as {{string_type}}) as "field 4"
+FROM source_data WHERE id NOT IN (SELECT id from {{ this }} )
+
+{% else %}
+
+SELECT id,
+       cast(field1 as {{string_type}}) as field1,
+       cast(field2 as {{string_type}}) as field2
+FROM source_data where id <= 3
+
+{% endif %}
+"""
+
+class TestIncrementalOnSchemaChangeQuotingFalse(BaseIncrementalOnSchemaChangeSetup):     
+    """ We need a new class based on the _Setup base class to allow project config change without repeating all other tests"""
+    @pytest.fixture(scope="class")
+    def models(self):
+        """ Override the models test fixture with the custom one injected """ 
+        # Get the original models dict
+        mods = dict(BaseIncrementalOnSchemaChange.models.__wrapped__(self))
+        # Add the custom model
+        mods["incremental_append_new_columns_with_space.sql"] = models__incremental_append_new_columns_with_space
+        return mods
+        
+    
+    def run_twice_and_return_status(self, select, expect_pass_2nd_run):
+        """Two runs of the specified models - return the status and message from the second"""
+        run_dbt(
+            ["run", "--select", select, "--full-refresh"],
+            expect_pass=True,
+        )
+        run_result = run_dbt(
+            ["run", "--select", select], expect_pass=expect_pass_2nd_run
+        ).results[-1]
+        return run_result.status, run_result.message
+
+        
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"quoting": {"identifier": False}}
+        
+    
+    def test__handle_identifier_quoting_config_false(self, project):        
+        # it should fail if quoting is set to false
+        (status, exc) = self.run_twice_and_return_status(
+            select="model_a incremental_append_new_columns_with_space",
+            expect_pass_2nd_run=False
+        )
+        assert status == RunStatus.Error
+
+class TestIncrementalOnSchemaChangeQuotingTrue(BaseIncrementalOnSchemaChangeSetup):     
+    """ We need a new class based on the _Setup base class to allow project config change without repeating all other tests"""
+    @pytest.fixture(scope="class")
+    def models(self):
+        """ Override the models test fixture with the custom one injected """ 
+        # Get the original models dict
+        mods = dict(BaseIncrementalOnSchemaChange.models.__wrapped__(self))
+        # Add the custom model
+        mods["incremental_append_new_columns_with_space.sql"] = models__incremental_append_new_columns_with_space
+        return mods
+        
+    
+    def run_twice_and_return_status(self, select, expect_pass_2nd_run):
+        """Two runs of the specified models - return the status and message from the second"""
+        run_dbt(
+            ["run", "--select", select, "--full-refresh"],
+            expect_pass=True,
+        )
+        run_result = run_dbt(
+            ["run", "--select", select], expect_pass=expect_pass_2nd_run
+        ).results[-1]
+        return run_result.status, run_result.message
+
+        
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"quoting": {"identifier": True}}
+        
+    
+    def test__handle_identifier_quoting_config_false(self, project):        
+        # it should fail if quoting is set to false
+        (status, exc) = self.run_twice_and_return_status(
+            select="model_a incremental_append_new_columns_with_space",
+            expect_pass_2nd_run=True
+        )
+        assert status == RunStatus.Success
+    


### PR DESCRIPTION
Ran into a bug in incremental models with `on_schema_change='append_new_columns'`. If the column names are invalid without quotes (e.g. have a space), the original `duckdb__alter_relation_add_remove_columns` macro inserting them raw would throw an error. 

* Updated the macro to use the dbt [Relation](https://docs.getdbt.com/reference/dbt-classes#creating-relations) method to respect the project's identifier quoting config.
* Added two tests:
  * First test confirms that incremental model adding a column with a space in the name **fails** if identifier quoting is `false`.
  * Second test confirms incremental add column **succeeds** if identifier quoting is `true`
  * Had to set up two new test classes from the `BaseIncrementalOnSchemaChangeSetup` class to be able to override project-level settings without stepping on (or redundantly running) the other tests in `BaseIncrementalOnSchemaChange`