### PR TITLE
Add support for arbitrary key-value pairs in Attachment ATTACH options

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,19 +212,19 @@ attach:
   - path: /tmp/db1.duckdb
     type: sqlite
     read_only: true
-    
+
   # New way using options dict (equivalent to above)
   - path: /tmp/db2.duckdb
     options:
       type: sqlite
       read_only: true
-      
+
   # Mix of both (no conflicts allowed)
   - path: /tmp/db3.duckdb
     type: sqlite
     options:
       block_size: 16384
-      
+
   # Using options dict for future DuckDB attachment options
   - path: /tmp/db4.duckdb
     options:

--- a/dbt/adapters/duckdb/credentials.py
+++ b/dbt/adapters/duckdb/credentials.py
@@ -43,7 +43,7 @@ class Attachment(dbtClassMixin):
         base = f"ATTACH '{path}'"
         if self.alias:
             base += f" AS {self.alias}"
-        
+
         # Check for conflicts between legacy fields and options dict
         if self.options:
             conflicts = []
@@ -53,46 +53,46 @@ class Attachment(dbtClassMixin):
                 conflicts.append("secret")
             if self.read_only and "read_only" in self.options:
                 conflicts.append("read_only")
-            
+
             if conflicts:
                 raise DbtRuntimeError(
                     f"Attachment option(s) {conflicts} specified in both direct fields and options dict. "
                     f"Please specify each option in only one location."
                 )
-        
+
         # Collect all options, prioritizing direct fields over options dict
         all_options = []
-        
+
         # Add legacy options for backward compatibility
         if self.type:
             all_options.append(f"TYPE {self.type}")
         elif self.options and "type" in self.options:
             all_options.append(f"TYPE {self.options['type']}")
-            
+
         if self.secret:
             all_options.append(f"SECRET {self.secret}")
         elif self.options and "secret" in self.options:
             all_options.append(f"SECRET {self.options['secret']}")
-            
+
         if self.read_only:
             all_options.append("READ_ONLY")
         elif self.options and "read_only" in self.options and self.options["read_only"]:
             all_options.append("READ_ONLY")
-        
+
         # Add arbitrary options from the options dict (excluding handled ones)
         if self.options:
             handled_keys = {"type", "secret", "read_only"}
             for key, value in self.options.items():
                 if key in handled_keys:
                     continue
-                
+
                 # Format the option appropriately
                 if isinstance(value, bool):
                     if value:  # Only add boolean options if they're True
                         all_options.append(key.upper())
                 elif value is not None:
                     all_options.append(f"{key.upper()} {value}")
-        
+
         if all_options:
             joined = ", ".join(all_options)
             base += f" ({joined})"

--- a/dbt/adapters/duckdb/credentials.py
+++ b/dbt/adapters/duckdb/credentials.py
@@ -33,6 +33,9 @@ class Attachment(dbtClassMixin):
     # Whether the attached database is read-only or read/write
     read_only: bool = False
 
+    # Arbitrary key-value pairs for additional ATTACH options
+    options: Optional[Dict[str, Any]] = None
+
     def to_sql(self) -> str:
         # remove query parameters (not supported in ATTACH)
         parsed = urlparse(self.path)
@@ -40,15 +43,58 @@ class Attachment(dbtClassMixin):
         base = f"ATTACH '{path}'"
         if self.alias:
             base += f" AS {self.alias}"
-        options = []
+        
+        # Check for conflicts between legacy fields and options dict
+        if self.options:
+            conflicts = []
+            if self.type and "type" in self.options:
+                conflicts.append("type")
+            if self.secret and "secret" in self.options:
+                conflicts.append("secret")
+            if self.read_only and "read_only" in self.options:
+                conflicts.append("read_only")
+            
+            if conflicts:
+                raise DbtRuntimeError(
+                    f"Attachment option(s) {conflicts} specified in both direct fields and options dict. "
+                    f"Please specify each option in only one location."
+                )
+        
+        # Collect all options, prioritizing direct fields over options dict
+        all_options = []
+        
+        # Add legacy options for backward compatibility
         if self.type:
-            options.append(f"TYPE {self.type}")
+            all_options.append(f"TYPE {self.type}")
+        elif self.options and "type" in self.options:
+            all_options.append(f"TYPE {self.options['type']}")
+            
         if self.secret:
-            options.append(f"SECRET {self.secret}")
+            all_options.append(f"SECRET {self.secret}")
+        elif self.options and "secret" in self.options:
+            all_options.append(f"SECRET {self.options['secret']}")
+            
         if self.read_only:
-            options.append("READ_ONLY")
-        if options:
-            joined = ", ".join(options)
+            all_options.append("READ_ONLY")
+        elif self.options and "read_only" in self.options and self.options["read_only"]:
+            all_options.append("READ_ONLY")
+        
+        # Add arbitrary options from the options dict (excluding handled ones)
+        if self.options:
+            handled_keys = {"type", "secret", "read_only"}
+            for key, value in self.options.items():
+                if key in handled_keys:
+                    continue
+                
+                # Format the option appropriately
+                if isinstance(value, bool):
+                    if value:  # Only add boolean options if they're True
+                        all_options.append(key.upper())
+                elif value is not None:
+                    all_options.append(f"{key.upper()} {value}")
+        
+        if all_options:
+            joined = ", ".join(all_options)
             base += f" ({joined})"
         return base
 


### PR DESCRIPTION
## Summary
• Adds support for arbitrary key-value pairs in database attachment configuration via a new `options` dictionary
• Maintains backward compatibility with existing direct field configuration (`type`, `secret`, `read_only`)
• Provides conflict detection to prevent specifying the same option in both direct fields and options dict

## Key Changes
- Added `options` field to `Attachment` class for arbitrary ATTACH options
- Updated `to_sql()` method to handle both legacy fields and new options dict
- Added comprehensive test coverage for new functionality and conflict detection
- Updated README documentation with examples of new configuration format

## Use Case
This enhancement allows users to leverage new DuckDB attachment features without waiting for explicit support in dbt-duckdb. For example, users can now specify cache sizes, thread counts, and other advanced options that DuckDB supports in ATTACH statements.

## Test plan
- [x] Added unit tests for options dict functionality
- [x] Added tests for conflict detection between legacy fields and options
- [x] Verified backward compatibility with existing configurations
- [x] Updated documentation with clear examples

🤖 Generated with [Claude Code](https://claude.ai/code)