### PR TITLE
Update macros for dropping schema and relations when using ducklake

### DIFF
--- a/dbt/include/duckdb/macros/adapters.sql
+++ b/dbt/include/duckdb/macros/adapters.sql
@@ -164,11 +164,7 @@ def materialize(df, con):
 
 {% macro duckdb__drop_relation(relation) -%}
   {% call statement('drop_relation', auto_begin=False) -%}
-    {% if relation.path is defined and relation.path.startswith('ducklake:') %}
-      {{ log("Dropping ducklake relation without cascade: " ~ relation, info=True) }}
       drop {{ relation.type }} if exists {{ relation }}
-    {% else %}
-      drop {{ relation.type }} if exists {{ relation }} cascade
     {% endif %}
   {%- endcall %}
 {% endmacro %}

--- a/dbt/include/duckdb/macros/adapters.sql
+++ b/dbt/include/duckdb/macros/adapters.sql
@@ -164,7 +164,7 @@ def materialize(df, con):
 
 {% macro duckdb__drop_relation(relation) -%}
   {% call statement('drop_relation', auto_begin=False) -%}
-      drop {{ relation.type }} if exists {{ relation }}
+      drop {{ relation.type }} jif exists {{ relation }}
     {% endif %}
   {%- endcall %}
 {% endmacro %}

--- a/dbt/include/duckdb/macros/adapters.sql
+++ b/dbt/include/duckdb/macros/adapters.sql
@@ -164,7 +164,11 @@ def materialize(df, con):
 
 {% macro duckdb__drop_relation(relation) -%}
   {% call statement('drop_relation', auto_begin=False) -%}
-      drop {{ relation.type }} jif exists {{ relation }}
+    {% if relation.path is defined and relation.path.startswith('ducklake:') %}
+      {{ log("Dropping ducklake relation without cascade: " ~ relation, info=True) }}
+      drop {{ relation.type }} if exists {{ relation }}
+    {% else %}
+      drop {{ relation.type }} if exists {{ relation }} cascade
     {% endif %}
   {%- endcall %}
 {% endmacro %}

--- a/dbt/include/duckdb/macros/adapters.sql
+++ b/dbt/include/duckdb/macros/adapters.sql
@@ -164,7 +164,8 @@ def materialize(df, con):
 
 {% macro duckdb__drop_relation(relation) -%}
   {% call statement('drop_relation', auto_begin=False) -%}
-    {% if relation.path is defined and relation.path.identifier is defined and relation.path.identifier | string | lower is string and relation.path.identifier | string | lower starts with 'ducklake:' %}
+    {% set relation_str = relation | string %}
+    {% if 'ducklake:' in relation_str %}
       {{ log("Dropping ducklake relation without cascade: " ~ relation, info=True) }}
       drop {{ relation.type }} if exists {{ relation }}
     {% else %}

--- a/dbt/include/duckdb/macros/adapters.sql
+++ b/dbt/include/duckdb/macros/adapters.sql
@@ -164,7 +164,7 @@ def materialize(df, con):
 
 {% macro duckdb__drop_relation(relation) -%}
   {% call statement('drop_relation', auto_begin=False) -%}
-    {% if relation.path is defined and relation.path.startswith('ducklake:') %}
+    {% if relation.path is defined and relation.path.identifier is defined and relation.path.identifier | string | lower is string and relation.path.identifier | string | lower starts with 'ducklake:' %}
       {{ log("Dropping ducklake relation without cascade: " ~ relation, info=True) }}
       drop {{ relation.type }} if exists {{ relation }}
     {% else %}

--- a/dbt/include/duckdb/macros/adapters.sql
+++ b/dbt/include/duckdb/macros/adapters.sql
@@ -164,7 +164,12 @@ def materialize(df, con):
 
 {% macro duckdb__drop_relation(relation) -%}
   {% call statement('drop_relation', auto_begin=False) -%}
-    drop {{ relation.type }} if exists {{ relation }} cascade
+    {% if relation.path is defined and relation.path.startswith('ducklake:') %}
+      {{ log("Dropping ducklake relation without cascade: " ~ relation, info=True) }}
+      drop {{ relation.type }} if exists {{ relation }}
+    {% else %}
+      drop {{ relation.type }} if exists {{ relation }} cascade
+    {% endif %}
   {%- endcall %}
 {% endmacro %}
 

--- a/dbt/include/duckdb/macros/adapters.sql
+++ b/dbt/include/duckdb/macros/adapters.sql
@@ -36,7 +36,6 @@
     {% endif %}
     
     {% if ns.is_ducklake %}
-      {{ log("Dropping ducklake schema without cascade: " ~ relation.without_identifier(), info=True) }}
       drop schema if exists {{ relation.without_identifier() }}
     {% else %}
       drop schema if exists {{ relation.without_identifier() }} cascade
@@ -198,7 +197,6 @@ def materialize(df, con):
     {% endif %}
     
     {% if ns.is_ducklake %}
-      {{ log("Dropping ducklake relation without cascade: " ~ relation, info=True) }}
       drop {{ relation.type }} if exists {{ relation }}
     {% else %}
       drop {{ relation.type }} if exists {{ relation }} cascade

--- a/dbt/include/duckdb/macros/adapters.sql
+++ b/dbt/include/duckdb/macros/adapters.sql
@@ -164,8 +164,7 @@ def materialize(df, con):
 
 {% macro duckdb__drop_relation(relation) -%}
   {% call statement('drop_relation', auto_begin=False) -%}
-    {% set relation_str = relation | string %}
-    {% if 'ducklake:' in relation_str %}
+    {% if relation.path is defined and relation.path.database is defined and 'ducklake:' in relation.path.database %}
       {{ log("Dropping ducklake relation without cascade: " ~ relation, info=True) }}
       drop {{ relation.type }} if exists {{ relation }}
     {% else %}

--- a/dbt/include/duckdb/macros/adapters.sql
+++ b/dbt/include/duckdb/macros/adapters.sql
@@ -164,7 +164,8 @@ def materialize(df, con):
 
 {% macro duckdb__drop_relation(relation) -%}
   {% call statement('drop_relation', auto_begin=False) -%}
-    {% if relation.path is defined and relation.path.database is defined and 'ducklake:' in relation.path.database %}
+    {% set database = relation.database %}
+    {% if database is not none and 'ducklake:' in database %}
       {{ log("Dropping ducklake relation without cascade: " ~ relation, info=True) }}
       drop {{ relation.type }} if exists {{ relation }}
     {% else %}


### PR DESCRIPTION
This PR implements special handling for ducklake relations in the duckdb__drop_relation and
duckdb__drop_schema macros.

Changes:

 • The duckdb__drop_relation macro now detects ducklake relations by checking if the
   relation's database matches an attachment alias with a ducklake path
 • The duckdb__drop_schema macro uses the same detection logic
 • For ducklake relations/schemas, we drop without the CASCADE option
 • For non-ducklake relations/schemas, we use CASCADE when dropping

Ducklake relations require special handling when being dropped. This implementation ensures
that ducklake relations are properly detected based on the attachment configuration in the
profile.

This might be too much of an edit for the adapters.sql but it does fix the cascade issue. I tested by creating these macros in my own dbt project and then testing the table materialization. I'm not totally sure when the schema drop gets called but I added the same logic there anyway. 