### PR TITLE
FIX: Fixes issue caused by external materializations with column name contains spaces

### DIFF
--- a/dbt/include/duckdb/macros/materializations/external.sql
+++ b/dbt/include/duckdb/macros/materializations/external.sql
@@ -97,7 +97,7 @@
         {% if row_count[0][0] == 0 %}
           where 1
           {%- for col in get_columns_in_relation(temp_relation) -%}
-            {{ '' }} AND {{ col.column }} is not NULL
+            {{ '' }} AND "{{ col.column }}" is not NULL
           {%- endfor -%}
         {% endif %}
       );
@@ -117,7 +117,7 @@
         {% if row_count[0][0] == 0 %}
           where 1
           {%- for col in get_columns_in_relation(temp_relation) -%}
-            {{ '' }} AND {{ col.column }} is not NULL
+            {{ '' }} AND "{{ col.column }}" is not NULL
           {%- endfor -%}
         {% endif %}
       );
@@ -137,7 +137,7 @@
       {% if row_count[0][0] == 0 %}
         where 1
         {%- for col in get_columns_in_relation(temp_relation) -%}
-          {{ '' }} AND {{ col.column }} is not NULL
+          {{ '' }} AND "{{ col.column }}" is not NULL
         {%- endfor -%}
       {% endif %}
     );


### PR DESCRIPTION
This pull request makes a small but important adjustment to the SQL syntax in the `external.sql` file for DuckDB materializations. Specifically, it ensures that column names are properly quoted to avoid syntax errors or conflicts with reserved keywords, special characters, or spaces in the column names.

Key change:

* [`dbt/include/duckdb/macros/materializations/external.sql`](diffhunk://#diff-8b1decdd0636715db41bd9b03c973f95a8c1168217bb025803aaed775c27b50eL100-R100): Updated the SQL syntax to quote column names (`"{{ col.column }}"`) in three separate instances within the materialization logic to ensure compatibility and correctness. [[1]](diffhunk://#diff-8b1decdd0636715db41bd9b03c973f95a8c1168217bb025803aaed775c27b50eL100-R100) [[2]](diffhunk://#diff-8b1decdd0636715db41bd9b03c973f95a8c1168217bb025803aaed775c27b50eL120-R120) [[3]](diffhunk://#diff-8b1decdd0636715db41bd9b03c973f95a8c1168217bb025803aaed775c27b50eL140-R140)