### PR TITLE
Assume native comment support in DuckDB catalog queries

### DIFF
--- a/dbt/adapters/duckdb/environments/__init__.py
+++ b/dbt/adapters/duckdb/environments/__init__.py
@@ -88,12 +88,6 @@ class Environment(abc.ABC):
                 if path not in sys.path:
                     sys.path.append(path)
 
-        major, minor, patch = [int(x) for x in duckdb.__version__.split("-")[0].split(".")]
-        if major == 0 and (minor < 10 or (minor == 10 and patch == 0)):
-            self._supports_comments = False
-        else:
-            self._supports_comments = True
-
     @property
     def creds(self) -> DuckDBCredentials:
         return self._creds
@@ -116,9 +110,6 @@ class Environment(abc.ABC):
 
     def get_binding_char(self) -> str:
         return "?"
-
-    def supports_comments(self) -> bool:
-        return self._supports_comments
 
     @classmethod
     @abc.abstractmethod

--- a/dbt/adapters/duckdb/impl.py
+++ b/dbt/adapters/duckdb/impl.py
@@ -137,10 +137,6 @@ class DuckDBAdapter(SQLAdapter):
         return DuckDBConnectionManager.env().get_binding_char()
 
     @available
-    def catalog_comment(self, prefix):
-        return f"{prefix}.comment"
-
-    @available
     def external_write_options(self, write_location: str, rendered_options: dict) -> str:
         if "format" not in rendered_options:
             ext = os.path.splitext(write_location)[1].lower()

--- a/dbt/adapters/duckdb/impl.py
+++ b/dbt/adapters/duckdb/impl.py
@@ -138,10 +138,7 @@ class DuckDBAdapter(SQLAdapter):
 
     @available
     def catalog_comment(self, prefix):
-        if DuckDBConnectionManager.env().supports_comments():
-            return f"{prefix}.comment"
-        else:
-            return "''"
+        return f"{prefix}.comment"
 
     @available
     def external_write_options(self, write_location: str, rendered_options: dict) -> str:

--- a/dbt/include/duckdb/macros/catalog.sql
+++ b/dbt/include/duckdb/macros/catalog.sql
@@ -7,7 +7,7 @@
         , t.database_name
         , t.schema_name
         , 'BASE TABLE' as table_type
-        , {{ adapter.catalog_comment('t') }} as table_comment
+        , t.comment as table_comment
       from duckdb_tables() t
       WHERE t.database_name = '{{ database }}'
       UNION ALL
@@ -15,7 +15,7 @@
       , v.database_name
       , v.schema_name
       , 'VIEW' as table_type
-      , {{ adapter.catalog_comment('v') }} as table_comment
+      , v.comment as table_comment
       from duckdb_views() v
       WHERE v.database_name = '{{ database }}'
     )
@@ -28,7 +28,7 @@
         c.column_name,
         c.column_index as column_index,
         c.data_type as column_type,
-        {{ adapter.catalog_comment('c') }} as column_comment,
+        c.comment as column_comment,
         NULL as table_owner
     FROM relations r JOIN duckdb_columns() c ON r.schema_name = c.schema_name AND r.table_name = c.table_name
     WHERE (


### PR DESCRIPTION
## Summary
- Removes the custom `catalog_comment` adapter method from the DuckDB adapter
- Updates catalog SQL macros to directly use DuckDB's native `comment` field instead of the adapter method

## Test plan
- [ ] Run existing catalog-related tests to ensure comment retrieval still works
- [ ] Verify that table and column comments are properly displayed in dbt docs

🤖 Generated with [Claude Code](https://claude.ai/code)