### PR TITLE
fix write conflict when first creating dbt_temp schema

### DIFF
--- a/dbt/adapters/duckdb/constants.py
+++ b/dbt/adapters/duckdb/constants.py
@@ -1,3 +1,2 @@
-
 TEMP_SCHEMA_NAME = "temp_schema_name"
 DEFAULT_TEMP_SCHEMA_NAME = "dbt_temp"

--- a/dbt/adapters/duckdb/constants.py
+++ b/dbt/adapters/duckdb/constants.py
@@ -1,0 +1,3 @@
+
+TEMP_SCHEMA_NAME = "temp_schema_name"
+DEFAULT_TEMP_SCHEMA_NAME = "dbt_temp"

--- a/dbt/adapters/duckdb/environments/__init__.py
+++ b/dbt/adapters/duckdb/environments/__init__.py
@@ -197,7 +197,7 @@ class Environment(abc.ABC):
                 conn.execute(attachment.to_sql())
 
         if creds.is_motherduck:
-            # Each incremental model will try to create a temporary schema, commonly the 
+            # Each incremental model will try to create a temporary schema, usually the 
             # DEFAULT_TEMP_SCHEMA_NAME, in its own transaction, which will result in all 
             # except the first-run model to fail with a write-write conflict. By creating
             # the schema here, we make the CREATE SCHEMA statement in the incremental models

--- a/dbt/adapters/duckdb/environments/__init__.py
+++ b/dbt/adapters/duckdb/environments/__init__.py
@@ -197,11 +197,11 @@ class Environment(abc.ABC):
                 conn.execute(attachment.to_sql())
 
         if creds.is_motherduck:
-            # Each incremental model will try to create a temporary schema, usually the 
-            # DEFAULT_TEMP_SCHEMA_NAME, in its own transaction, which will result in all 
+            # Each incremental model will try to create a temporary schema, usually the
+            # DEFAULT_TEMP_SCHEMA_NAME, in its own transaction, which will result in all
             # except the first-run model to fail with a write-write conflict. By creating
             # the schema here, we make the CREATE SCHEMA statement in the incremental models
-            # a no-op, which will prevent the write-write conflict. 
+            # a no-op, which will prevent the write-write conflict.
             conn.execute("CREATE SCHEMA IF NOT EXISTS {}".format(DEFAULT_TEMP_SCHEMA_NAME))
 
         return conn

--- a/dbt/adapters/duckdb/environments/__init__.py
+++ b/dbt/adapters/duckdb/environments/__init__.py
@@ -11,6 +11,7 @@ from typing import Optional
 import duckdb
 from dbt_common.exceptions import DbtRuntimeError
 
+from ..constants import DEFAULT_TEMP_SCHEMA_NAME
 from ..credentials import DuckDBCredentials
 from ..credentials import Extension
 from ..plugins import BasePlugin
@@ -194,6 +195,14 @@ class Environment(abc.ABC):
         if creds.attach:
             for attachment in creds.attach:
                 conn.execute(attachment.to_sql())
+
+        if creds.is_motherduck:
+            # Each incremental model will try to create a temporary schema, commonly the 
+            # DEFAULT_TEMP_SCHEMA_NAME, in its own transaction, which will result in all 
+            # except the first-run model to fail with a write-write conflict. By creating
+            # the schema here, we make the CREATE SCHEMA statement in the incremental models
+            # a no-op, which will prevent the write-write conflict. 
+            conn.execute("CREATE SCHEMA IF NOT EXISTS {}".format(DEFAULT_TEMP_SCHEMA_NAME))
 
         return conn
 

--- a/dbt/adapters/duckdb/impl.py
+++ b/dbt/adapters/duckdb/impl.py
@@ -26,10 +26,8 @@ from dbt.adapters.duckdb.utils import TargetConfig
 from dbt.adapters.duckdb.utils import TargetLocation
 from dbt.adapters.events.logging import AdapterLogger
 from dbt.adapters.sql import SQLAdapter
+from .constants import DEFAULT_TEMP_SCHEMA_NAME, TEMP_SCHEMA_NAME
 
-
-TEMP_SCHEMA_NAME = "temp_schema_name"
-DEFAULT_TEMP_SCHEMA_NAME = "dbt_temp"
 
 if TYPE_CHECKING:
     import agate

--- a/dbt/adapters/duckdb/impl.py
+++ b/dbt/adapters/duckdb/impl.py
@@ -12,6 +12,8 @@ from dbt_common.contracts.constraints import ConstraintType
 from dbt_common.exceptions import DbtInternalError
 from dbt_common.exceptions import DbtRuntimeError
 
+from .constants import DEFAULT_TEMP_SCHEMA_NAME
+from .constants import TEMP_SCHEMA_NAME
 from dbt.adapters.base import BaseRelation
 from dbt.adapters.base.column import Column as BaseColumn
 from dbt.adapters.base.impl import ConstraintSupport
@@ -26,7 +28,6 @@ from dbt.adapters.duckdb.utils import TargetConfig
 from dbt.adapters.duckdb.utils import TargetLocation
 from dbt.adapters.events.logging import AdapterLogger
 from dbt.adapters.sql import SQLAdapter
-from .constants import DEFAULT_TEMP_SCHEMA_NAME, TEMP_SCHEMA_NAME
 
 
 if TYPE_CHECKING:

--- a/dbt/adapters/duckdb/utils.py
+++ b/dbt/adapters/duckdb/utils.py
@@ -11,6 +11,7 @@ from dbt.adapters.contracts.relation import RelationConfig
 # TODO
 # from dbt.context.providers import RuntimeConfigObject
 
+
 @dataclass
 class SourceConfig:
     name: str

--- a/dbt/adapters/duckdb/utils.py
+++ b/dbt/adapters/duckdb/utils.py
@@ -11,7 +11,6 @@ from dbt.adapters.contracts.relation import RelationConfig
 # TODO
 # from dbt.context.providers import RuntimeConfigObject
 
-
 @dataclass
 class SourceConfig:
     name: str

--- a/tests/functional/plugins/motherduck/test_motherduck_write_conflict.py
+++ b/tests/functional/plugins/motherduck/test_motherduck_write_conflict.py
@@ -1,0 +1,83 @@
+import pytest
+from dbt.tests.util import run_dbt
+from dbt.exceptions import DbtRuntimeError
+
+
+incremental_model_1_sql = """
+{{ config(materialized='incremental') }}
+
+select 
+    generate_series as id,
+    'model_1_data_' || generate_series::varchar as data,
+    current_timestamp as created_at
+from generate_series(1, 100)
+
+{% if is_incremental() %}
+    where generate_series > (select coalesce(max(id), 0) from {{ this }})
+{% endif %}
+"""
+
+incremental_model_2_sql = """
+{{ config(materialized='incremental') }}
+
+select 
+    generate_series as id,
+    'model_2_data_' || generate_series::varchar as data,
+    current_timestamp as created_at
+from generate_series(1, 50)
+
+{% if is_incremental() %}
+    where generate_series > (select coalesce(max(id), 0) from {{ this }})
+{% endif %}
+"""
+
+
+@pytest.mark.skip_profile("buenavista", "file", "memory")
+class TestMDWriteConflict:
+    """Test to reproduce the write-write conflict with multiple models trying to create the dbt_temp schema concurrently."""
+
+    @pytest.fixture(scope="class")
+    def profiles_config_update(self, dbt_profile_target):
+        """Configure with 2 threads to trigger write conflict."""
+        return {
+            "test": {
+                "outputs": {
+                    "dev": {
+                        "type": "duckdb",
+                        "path": "test_write_conflict.duckdb",
+                        "attach": [
+                            {
+                                "path": "md:",
+                            }  # Attach MotherDuck
+                        ],
+                        "threads": 2,  # Enable threading to trigger conflict
+                    }
+                },
+                "target": "dev",
+            }
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "incremental_model_1.sql": incremental_model_1_sql,
+            "incremental_model_2.sql": incremental_model_2_sql,
+        }
+
+    def test_write_conflict_on_second_run(self, project):
+        """
+        Test that reproduces the write-write conflict:
+        1. First run always succeeds (initializes both incremental models)
+        2. Second run, which is the first true incremental run, should succeed, 
+            while it previously failed with a write-write conflict due to
+            both models trying to create the dbt_temp schema simultaneously.
+        """
+        results = run_dbt(expect_pass=True)
+
+        res1 = project.run_sql("SELECT count(*) FROM incremental_model_1", fetch="one")
+        assert res1[0] == 100
+
+        res2 = project.run_sql("SELECT count(*) FROM incremental_model_2", fetch="one")
+        assert res2[0] == 50
+
+        run_dbt(expect_pass=True)


### PR DESCRIPTION
I believe this fixes the root cause of https://github.com/duckdb/dbt-duckdb/issues/513 

## Problem
Currently, when using MotherDuck with dbt-duckdb, a real temp schema and real tables will be created to store the staging tables, because temp tables are not yet supported. By default this schema is called `dbt_temp`. When running dbt with 2 or more threads, each incremental model will open a transaction that starts with the statement `CREATE SCHEMA IF NOT EXISTS dbt_temp`. The model that gets executed first will cause a catalog change with the `CREATE SCHEMA` statement while its transaction is still open, while the rest of the models will fail with a write-write conflict on that statement. 

## Solution & Considerations
If the schema `dbt_temp` already exists, then the `CREATE SCHEMA` statement will be a no-op, then all incremental models will succeed. 
So ideally, the create schema statement should be run just once at the beginning of a dbt run. But the current implementation allows each model to configure their own temp schema. This means that we won't fully know the name of the schema that needs to be created until processing the model, also that the`CREATE SCHEMA IF NOT EXISTS {temp_schema_name}` statement in `macros/materializations/incremental.sql` needs to be preserved. 
So the fix will just address the problem of creating the default temp schema `dbt_temp`, by running `CREATE SCHEMA IF NOT EXISTS  dbt_temp` when initializing the connection. 