### PR TITLE
Make the adapter.commit call inside of upstream.sql dependent on `upstream_nodes` existing

### DIFF
--- a/dbt/include/duckdb/macros/utils/upstream.sql
+++ b/dbt/include/duckdb/macros/utils/upstream.sql
@@ -35,6 +35,8 @@
     {% endif %}
   {% endfor %}
 {% endfor %}
-{% do adapter.commit() %}
+{% if upstream_nodes %}
+  {% do adapter.commit() %}
+{% endif %}
 {% endif %}
 {%- endmacro -%}


### PR DESCRIPTION
This eliminates a spurious error that could be triggered under some conditions that we would like to eliminate (see #587 )