### PR TITLE
Fix incremental Python models on MotherDuck

### DIFF
--- a/dbt/include/duckdb/macros/materializations/incremental.sql
+++ b/dbt/include/duckdb/macros/materializations/incremental.sql
@@ -49,7 +49,7 @@
       {% do to_drop.append(temp_relation) %}
     {% endif %}
     {% if language == 'python' %}
-      {% set build_python = create_table_as(False, temp_relation, compiled_code, language) %}
+      {% set build_python = create_table_as(temporary, temp_relation, compiled_code, language) %}
       {% call statement("pre", language=language) %}
         {{- build_python }}
       {% endcall %}


### PR DESCRIPTION
I ran into issues with incremental Python models. The temp table created in dbt_temp is created after the query is executed leading into a table not found error. As far as I can see this seems a small omission in the create_table_as function when the language is set to Python, although I am uncertain if this is done for a specific reason. Nothing seems to be mentioned here: https://github.com/duckdb/dbt-duckdb/pull/326.