### PR TITLE
Add struct column support with flatten functionality

### DIFF
--- a/dbt/adapters/duckdb/column.py
+++ b/dbt/adapters/duckdb/column.py
@@ -1,10 +1,47 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
+from dataclasses import field
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
 
 from dbt.adapters.base.column import Column
 
 
 @dataclass
 class DuckDBColumn(Column):
+    # https://github.com/dbt-labs/dbt-bigquery/blob/main/dbt/adapters/bigquery/column.py
+    fields: List[DuckDBColumn] = field(default_factory=list)
+
+    def __post_init__(self):
+        # Convert any dicts in self.fields to DuckDBColumn objects
+        self.fields = [
+            f if isinstance(f, DuckDBColumn) else DuckDBColumn.create_from_dict(f)
+            for f in self.fields
+        ]
+
+    @classmethod
+    def create_from_dict(cls, column_dict: Dict[str, Any]) -> DuckDBColumn:
+        if isinstance(column_dict, DuckDBColumn):
+            return column_dict
+
+        return DuckDBColumn(
+            column=column_dict["column"],
+            dtype=column_dict["dtype"],
+            char_size=column_dict.get("char_size"),
+            numeric_precision=column_dict.get("numeric_precision"),
+            numeric_scale=column_dict.get("numeric_scale"),
+            fields=column_dict.get("fields", []),
+        )
+
+    @classmethod
+    def create(
+        cls, column: str, dtype: str, fields: Optional[List[DuckDBColumn]] = None
+    ) -> DuckDBColumn:
+        return DuckDBColumn(column=column, dtype=dtype, fields=fields or [])
+
     def is_float(self):
         return self.dtype.lower() in {
             # floats
@@ -38,3 +75,37 @@ class DuckDBColumn(Column):
             "signed",
             "long",
         }
+
+    def is_struct(self) -> bool:
+        return self.dtype.lower().startswith("struct")
+
+    @property
+    def name(self) -> str:
+        return self.column
+
+    def flatten(self) -> List[DuckDBColumn]:
+        if not self.is_struct():
+            return [self]
+
+        flat_columns: List[DuckDBColumn] = []
+        for column_field in self.fields:
+            if column_field.is_struct():
+                # Recursively flatten the nested struct
+                nested_fields = column_field.flatten()
+                for nested_field in nested_fields:
+                    flat_columns.append(
+                        DuckDBColumn.create(
+                            f"{self.name}.{nested_field.name}",
+                            nested_field.dtype,
+                            fields=nested_field.fields,
+                        )
+                    )
+            else:
+                flat_columns.append(
+                    DuckDBColumn.create(
+                        f"{self.name}.{column_field.name}",
+                        column_field.dtype,
+                        fields=column_field.fields,
+                    )
+                )
+        return flat_columns

--- a/dbt/adapters/duckdb/column.py
+++ b/dbt/adapters/duckdb/column.py
@@ -51,10 +51,10 @@ class DuckDBColumn(Column):
             return [self]
 
         flat_columns: List["DuckDBColumn"] = []
-        for field in self.fields:
-            if field.is_struct():
+        for column_field in self.fields:
+            if column_field.is_struct():
                 # Recursively flatten nested structs
-                for nested_field in field.flatten():
+                for nested_field in column_field.flatten():
                     flat_columns.append(
                         DuckDBColumn(
                             column=f"{self.column}.{nested_field.column}",
@@ -64,8 +64,8 @@ class DuckDBColumn(Column):
             else:
                 flat_columns.append(
                     DuckDBColumn(
-                        column=f"{self.column}.{field.column}",
-                        dtype=field.dtype,
+                        column=f"{self.column}.{column_field.column}",
+                        dtype=column_field.dtype,
                     )
                 )
         return flat_columns

--- a/dbt/adapters/duckdb/column.py
+++ b/dbt/adapters/duckdb/column.py
@@ -1,46 +1,13 @@
-from __future__ import annotations
-
 from dataclasses import dataclass
 from dataclasses import field
-from typing import Any
-from typing import Dict
 from typing import List
-from typing import Optional
 
 from dbt.adapters.base.column import Column
 
 
 @dataclass
 class DuckDBColumn(Column):
-    # https://github.com/dbt-labs/dbt-bigquery/blob/main/dbt/adapters/bigquery/column.py
-    fields: List[DuckDBColumn] = field(default_factory=list)
-
-    def __post_init__(self):
-        # Convert any dicts in self.fields to DuckDBColumn objects
-        self.fields = [
-            f if isinstance(f, DuckDBColumn) else DuckDBColumn.create_from_dict(f)
-            for f in self.fields
-        ]
-
-    @classmethod
-    def create_from_dict(cls, column_dict: Dict[str, Any]) -> DuckDBColumn:
-        if isinstance(column_dict, DuckDBColumn):
-            return column_dict
-
-        return DuckDBColumn(
-            column=column_dict["column"],
-            dtype=column_dict["dtype"],
-            char_size=column_dict.get("char_size"),
-            numeric_precision=column_dict.get("numeric_precision"),
-            numeric_scale=column_dict.get("numeric_scale"),
-            fields=column_dict.get("fields", []),
-        )
-
-    @classmethod
-    def create(
-        cls, column: str, dtype: str, fields: Optional[List[DuckDBColumn]] = None
-    ) -> DuckDBColumn:
-        return DuckDBColumn(column=column, dtype=dtype, fields=fields or [])
+    fields: List["DuckDBColumn"] = field(default_factory=list)
 
     def is_float(self):
         return self.dtype.lower() in {
@@ -79,33 +46,26 @@ class DuckDBColumn(Column):
     def is_struct(self) -> bool:
         return self.dtype.lower().startswith("struct")
 
-    @property
-    def name(self) -> str:
-        return self.column
-
-    def flatten(self) -> List[DuckDBColumn]:
+    def flatten(self) -> List["DuckDBColumn"]:
         if not self.is_struct():
             return [self]
 
-        flat_columns: List[DuckDBColumn] = []
-        for column_field in self.fields:
-            if column_field.is_struct():
-                # Recursively flatten the nested struct
-                nested_fields = column_field.flatten()
-                for nested_field in nested_fields:
+        flat_columns: List["DuckDBColumn"] = []
+        for field in self.fields:
+            if field.is_struct():
+                # Recursively flatten nested structs
+                for nested_field in field.flatten():
                     flat_columns.append(
-                        DuckDBColumn.create(
-                            f"{self.name}.{nested_field.name}",
-                            nested_field.dtype,
-                            fields=nested_field.fields,
+                        DuckDBColumn(
+                            column=f"{self.column}.{nested_field.column}",
+                            dtype=nested_field.dtype,
                         )
                     )
             else:
                 flat_columns.append(
-                    DuckDBColumn.create(
-                        f"{self.name}.{column_field.name}",
-                        column_field.dtype,
-                        fields=column_field.fields,
+                    DuckDBColumn(
+                        column=f"{self.column}.{field.column}",
+                        dtype=field.dtype,
                     )
                 )
         return flat_columns

--- a/dbt/adapters/duckdb/impl.py
+++ b/dbt/adapters/duckdb/impl.py
@@ -234,7 +234,7 @@ class DuckDBAdapter(SQLAdapter):
         return sql
 
     @available.parse(lambda *a, **k: [])
-    def get_column_schema_from_query(self, sql: str) -> List[BaseColumn]:
+    def get_column_schema_from_query(self, sql: str) -> Sequence[BaseColumn]:
         """Get a list of the Columns with names and data types from the given sql."""
 
         # Taking advantage of yet another amazing DuckDB SQL feature right here: the

--- a/tests/unit/test_column.py
+++ b/tests/unit/test_column.py
@@ -14,7 +14,7 @@ from dbt.adapters.duckdb.column import DuckDBColumn
     ("bigint", False)
 ])
 def test_is_float(dtype, expected):
-    column = DuckDBColumn(column="float_test", dtype=dtype)
+    column = DuckDBColumn.create(column="float_test", dtype=dtype)
     assert column.is_float() == expected
 
 # Test cases for is_integer method
@@ -41,5 +41,78 @@ def test_is_float(dtype, expected):
     ("double", False)
 ])
 def test_is_integer(dtype, expected):
-    column = DuckDBColumn(column="integer_test", dtype=dtype)
+    column = DuckDBColumn.create(column="integer_test", dtype=dtype)
     assert column.is_integer() == expected
+
+# Test cases for is_struct method
+@pytest.mark.parametrize("dtype, expected", [
+    ("struct(a integer, b varchar)", True),
+    ("struct(a integer)", True),
+    ("STRUCT(a integer, b varchar)", True),
+    ("integer", False),
+    ("varchar", False),
+])
+def test_is_struct(dtype, expected):
+    column = DuckDBColumn.create(column="struct_test", dtype=dtype)
+    assert column.is_struct() == expected
+
+# Test cases for flatten method
+def test_flatten_simple_struct():
+    fields = [
+        DuckDBColumn.create(column="a", dtype="integer"),
+        DuckDBColumn.create(column="b", dtype="varchar"),
+    ]
+    column = DuckDBColumn.create(column="struct_test", dtype="struct(a integer, b varchar)", fields=fields)
+    flattened = column.flatten()
+    assert len(flattened) == 2
+    assert flattened[0].name == "struct_test.a"
+    assert flattened[0].dtype == "integer"
+    assert flattened[1].name == "struct_test.b"
+    assert flattened[1].dtype == "varchar"
+
+def test_flatten_nested_struct():
+    nested_fields = [
+        DuckDBColumn.create(column="c", dtype="integer"),
+        DuckDBColumn.create(column="d", dtype="varchar"),
+    ]
+    fields = [
+        DuckDBColumn.create(column="a", dtype="integer"),
+        DuckDBColumn.create(column="b", dtype="struct(c integer, d varchar)", fields=nested_fields),
+    ]
+    column = DuckDBColumn.create(column="struct_test", dtype="struct(a integer, b struct(c integer, d varchar))", fields=fields)
+    flattened = column.flatten()
+    assert len(flattened) == 3
+    assert flattened[0].name == "struct_test.a"
+    assert flattened[0].dtype == "integer"
+    assert flattened[1].name == "struct_test.b.c"
+    assert flattened[1].dtype == "integer"
+    assert flattened[2].name == "struct_test.b.d"
+    assert flattened[2].dtype == "varchar"
+
+def test_flatten_non_struct():
+    column = DuckDBColumn.create(column="integer_test", dtype="integer")
+    flattened = column.flatten()
+    assert len(flattened) == 1
+    assert flattened[0].name == "integer_test"
+    assert flattened[0].dtype == "integer"
+
+# Test cases for create method
+def test_create_with_fields():
+    fields = [
+        DuckDBColumn.create(column="a", dtype="integer"),
+        DuckDBColumn.create(column="b", dtype="varchar"),
+    ]
+    column = DuckDBColumn.create(column="struct_test", dtype="struct(a integer, b varchar)", fields=fields)
+    assert column.name == "struct_test"
+    assert column.dtype == "struct(a integer, b varchar)"
+    assert len(column.fields) == 2
+    assert column.fields[0].name == "a"
+    assert column.fields[0].dtype == "integer"
+    assert column.fields[1].name == "b"
+    assert column.fields[1].dtype == "varchar"
+
+def test_create_without_fields():
+    column = DuckDBColumn.create(column="integer_test", dtype="integer")
+    assert column.name == "integer_test"
+    assert column.dtype == "integer"
+    assert len(column.fields) == 0

--- a/tests/unit/test_column.py
+++ b/tests/unit/test_column.py
@@ -14,7 +14,7 @@ from dbt.adapters.duckdb.column import DuckDBColumn
     ("bigint", False)
 ])
 def test_is_float(dtype, expected):
-    column = DuckDBColumn.create(column="float_test", dtype=dtype)
+    column = DuckDBColumn(column="float_test", dtype=dtype)
     assert column.is_float() == expected
 
 # Test cases for is_integer method
@@ -41,7 +41,7 @@ def test_is_float(dtype, expected):
     ("double", False)
 ])
 def test_is_integer(dtype, expected):
-    column = DuckDBColumn.create(column="integer_test", dtype=dtype)
+    column = DuckDBColumn(column="integer_test", dtype=dtype)
     assert column.is_integer() == expected
 
 # Test cases for is_struct method
@@ -53,66 +53,45 @@ def test_is_integer(dtype, expected):
     ("varchar", False),
 ])
 def test_is_struct(dtype, expected):
-    column = DuckDBColumn.create(column="struct_test", dtype=dtype)
+    column = DuckDBColumn(column="struct_test", dtype=dtype)
     assert column.is_struct() == expected
 
 # Test cases for flatten method
 def test_flatten_simple_struct():
     fields = [
-        DuckDBColumn.create(column="a", dtype="integer"),
-        DuckDBColumn.create(column="b", dtype="varchar"),
+        DuckDBColumn(column="a", dtype="integer"),
+        DuckDBColumn(column="b", dtype="varchar"),
     ]
-    column = DuckDBColumn.create(column="struct_test", dtype="struct(a integer, b varchar)", fields=fields)
+    column = DuckDBColumn(column="struct_test", dtype="struct(a integer, b varchar)", fields=fields)
     flattened = column.flatten()
     assert len(flattened) == 2
-    assert flattened[0].name == "struct_test.a"
+    assert flattened[0].column == "struct_test.a"
     assert flattened[0].dtype == "integer"
-    assert flattened[1].name == "struct_test.b"
+    assert flattened[1].column == "struct_test.b"
     assert flattened[1].dtype == "varchar"
 
 def test_flatten_nested_struct():
     nested_fields = [
-        DuckDBColumn.create(column="c", dtype="integer"),
-        DuckDBColumn.create(column="d", dtype="varchar"),
+        DuckDBColumn(column="c", dtype="integer"),
+        DuckDBColumn(column="d", dtype="varchar"),
     ]
     fields = [
-        DuckDBColumn.create(column="a", dtype="integer"),
-        DuckDBColumn.create(column="b", dtype="struct(c integer, d varchar)", fields=nested_fields),
+        DuckDBColumn(column="a", dtype="integer"),
+        DuckDBColumn(column="b", dtype="struct(c integer, d varchar)", fields=nested_fields),
     ]
-    column = DuckDBColumn.create(column="struct_test", dtype="struct(a integer, b struct(c integer, d varchar))", fields=fields)
+    column = DuckDBColumn(column="struct_test", dtype="struct(a integer, b struct(c integer, d varchar))", fields=fields)
     flattened = column.flatten()
     assert len(flattened) == 3
-    assert flattened[0].name == "struct_test.a"
+    assert flattened[0].column == "struct_test.a"
     assert flattened[0].dtype == "integer"
-    assert flattened[1].name == "struct_test.b.c"
+    assert flattened[1].column == "struct_test.b.c"
     assert flattened[1].dtype == "integer"
-    assert flattened[2].name == "struct_test.b.d"
+    assert flattened[2].column == "struct_test.b.d"
     assert flattened[2].dtype == "varchar"
 
 def test_flatten_non_struct():
-    column = DuckDBColumn.create(column="integer_test", dtype="integer")
+    column = DuckDBColumn(column="integer_test", dtype="integer")
     flattened = column.flatten()
     assert len(flattened) == 1
-    assert flattened[0].name == "integer_test"
+    assert flattened[0].column == "integer_test"
     assert flattened[0].dtype == "integer"
-
-# Test cases for create method
-def test_create_with_fields():
-    fields = [
-        DuckDBColumn.create(column="a", dtype="integer"),
-        DuckDBColumn.create(column="b", dtype="varchar"),
-    ]
-    column = DuckDBColumn.create(column="struct_test", dtype="struct(a integer, b varchar)", fields=fields)
-    assert column.name == "struct_test"
-    assert column.dtype == "struct(a integer, b varchar)"
-    assert len(column.fields) == 2
-    assert column.fields[0].name == "a"
-    assert column.fields[0].dtype == "integer"
-    assert column.fields[1].name == "b"
-    assert column.fields[1].dtype == "varchar"
-
-def test_create_without_fields():
-    column = DuckDBColumn.create(column="integer_test", dtype="integer")
-    assert column.name == "integer_test"
-    assert column.dtype == "integer"
-    assert len(column.fields) == 0


### PR DESCRIPTION
## Summary
- Adds struct column support to DuckDBColumn with field handling
- Implements recursive flattening of nested struct columns into dot-notation paths
- Provides clean, simple API without unnecessary factory methods

## Changes
- **DuckDBColumn**: Added `fields` property to support nested struct columns
- **Struct detection**: Added `is_struct` method to identify struct data types
- **Flattening**: Added `flatten` method to recursively flatten nested structs
- **Tests**: Added comprehensive test coverage for struct functionality
- **Type fixes**: Updated return type annotation in `get_column_schema_from_query`

## Test plan
- [x] All existing tests continue to pass
- [x] New struct detection tests validate `is_struct` method
- [x] Flatten tests cover simple and nested struct scenarios
- [x] Pre-commit hooks pass (linting, formatting, type checking)

🤖 Generated with [Claude Code](https://claude.ai/code)