### PR TITLE
Fix orchestrator compatibility: change logger.exception to logger.warning

### DIFF
--- a/dbt/adapters/duckdb/impl.py
+++ b/dbt/adapters/duckdb/impl.py
@@ -1,4 +1,5 @@
 import os
+import traceback
 from collections import defaultdict
 from typing import Any
 from typing import List
@@ -193,7 +194,7 @@ class DuckDBAdapter(SQLAdapter):
             self.connections.commit_if_has_connection()
         except DbtInternalError as e:
             # Log commit errors instead of silently swallowing them to aid debugging
-            logger.exception(f"Commit failed with DbtInternalError: {e}")
+            logger.warning(f"Commit failed with DbtInternalError: {e}\n{traceback.format_exc()}")
             # Still pass to maintain backward compatibility, but now with visibility
             pass
 


### PR DESCRIPTION
## Summary
• Replace logger.exception with logger.warning + traceback formatting to preserve stack trace info
• Fixes compatibility issue with orchestrators like Dagster that treat logger.exception calls as fatal exceptions

## Test plan
• All existing unit tests continue to pass (92 tests)
• Pre-commit hooks pass (mypy, ruff, etc.)
• Stack trace information is preserved in the warning log output

🤖 Generated with [Claude Code](https://claude.ai/code)