### PR TITLE
Update excel plugin to filter all null rows

### DIFF
--- a/dbt/adapters/duckdb/plugins/excel.py
+++ b/dbt/adapters/duckdb/plugins/excel.py
@@ -76,6 +76,7 @@ class Plugin(BasePlugin):
             target_output_config["sheet_name"] = sheet_name
 
         df = pd_utils.target_to_df(target_config)
+        df = df[df.notna().any(axis=1)]
         if target_output_config.get("skip_empty_sheet", False) and df.shape[0] == 0:
             return
         try:


### PR DESCRIPTION
The Excel writer "skip_empty_sheet" is not working as expected - its generating Excel sheets with empty data sets. This seems like it was a bug introduced in https://github.com/duckdb/dbt-duckdb/commit/41ff7622fb43086742070afc72014f166870cfb6 where a workaround was put in place to generate empty Parquet files.

We have a DBT model that conditionally generates data. When the condition is false it outputs a query like the following:

```
SELECT NULL WHERE FALSE
```

This results in a compiled target file with the same contents:

```
SELECT NULL WHERE FALSE
```

And a run target file with the following contents:

```
      create or replace view recurring_revenue_type_4__dbt_int" as (
        select * from read_parquet('s3://.../data_0.parquet', union_by_name=False)
        -- if relation is empty, filter by all columns having null values

          where 1 AND "NULL" is not NULL
      );
```

However, the Excel plugin reads the original Parquet file which contains the "empty" record. Therefore we need to implement the same WHERE filter when processing the Dataframe.