### PR TITLE
Add "type: ducklake" support for managed DuckLake

### DIFF
--- a/dbt/adapters/duckdb/credentials.py
+++ b/dbt/adapters/duckdb/credentials.py
@@ -229,14 +229,19 @@ class DuckDBCredentials(Credentials):
         self._ducklake_dbs = set()
         if self.attach:
             for attachment in self.attach:
-                if (
-                    hasattr(attachment, "alias")
-                    and attachment.alias
-                    and hasattr(attachment, "path")
-                    and attachment.path
-                    and "ducklake:" in attachment.path
-                ):
-                    self._ducklake_dbs.add(attachment.alias)
+                alias = getattr(attachment, "alias", None)
+                path = getattr(attachment, "path", None)
+                atype = getattr(attachment, "type", None)
+
+                # Detect ducklake by explicit type, or by path scheme. Be lenient on case.
+                is_ducklake = False
+                if isinstance(atype, str) and atype.lower() == "ducklake":
+                    is_ducklake = True
+                elif isinstance(path, str) and "ducklake:" in path.lower():
+                    is_ducklake = True
+
+                if alias and is_ducklake:
+                    self._ducklake_dbs.add(alias)
 
         # Add MotherDuck plugin if the path is a MotherDuck database
         # and plugin was not specified in profile.yml

--- a/tests/functional/plugins/motherduck/test_motherduck_ducklake.py
+++ b/tests/functional/plugins/motherduck/test_motherduck_ducklake.py
@@ -1,0 +1,75 @@
+import unittest
+from argparse import Namespace
+from unittest import mock
+
+from dbt.flags import set_from_args
+from dbt.adapters.duckdb import DuckDBAdapter
+from dbt.adapters.duckdb.relation import DuckDBRelation
+from tests.unit.utils import config_from_parts_or_dicts
+
+
+class TestMotherduckDucklakeDetection(unittest.TestCase):
+    def setUp(self):
+        set_from_args(Namespace(STRICT_MODE=True), {})
+
+        # Use a MotherDuck path to align with plugin context, but we won't actually connect
+        self.base_profile_cfg = {
+            "outputs": {
+                "test": {
+                    "type": "duckdb",
+                    "path": "md:my_db",
+                }
+            },
+            "target": "test",
+        }
+
+        project_cfg = {
+            "name": "X",
+            "version": "0.1",
+            "profile": "test",
+            "project-root": "/tmp/dbt/does-not-exist",
+            "quoting": {
+                "identifier": False,
+                "schema": True,
+            },
+            "config-version": 2,
+        }
+
+        self.project_cfg = project_cfg
+        self.mock_mp_context = mock.MagicMock()
+
+    def _get_adapter(self, profile_cfg):
+        config = config_from_parts_or_dicts(self.project_cfg, profile_cfg, cli_vars={})
+        return DuckDBAdapter(config, self.mock_mp_context)
+
+    def test_is_ducklake_with_type_ducklake(self):
+        profile_cfg = self.base_profile_cfg.copy()
+        profile_cfg["outputs"]["test"]["attach"] = [
+            {
+                "alias": "lk_db",
+                "path": "/path/to/regular.db",
+                "type": "ducklake",
+            }
+        ]
+
+        adapter = self._get_adapter(profile_cfg)
+        relation = DuckDBRelation.create(database="lk_db", schema="main", identifier="t")
+
+        assert adapter.is_ducklake(relation) is True
+
+    def test_is_ducklake_with_type_ducklake_case_insensitive(self):
+        profile_cfg = self.base_profile_cfg.copy()
+        profile_cfg["outputs"]["test"]["attach"] = [
+            {
+                "alias": "lk_db2",
+                "path": "/path/to/regular2.db",
+                "type": "DuckLake",
+            }
+        ]
+
+        adapter = self._get_adapter(profile_cfg)
+        relation = DuckDBRelation.create(database="lk_db2", schema="main", identifier="t2")
+
+        assert adapter.is_ducklake(relation) is True
+
+

--- a/tests/unit/test_duckdb_adapter.py
+++ b/tests/unit/test_duckdb_adapter.py
@@ -303,3 +303,39 @@ class TestDuckDBAdapterIsDucklake(unittest.TestCase):
         result = adapter.is_ducklake(relation)
         
         self.assertFalse(result)
+
+    def test_is_ducklake_with_type_ducklake(self):
+        """Test is_ducklake returns True when attachment type is ducklake even without ducklake: path."""
+        profile_cfg = self.base_profile_cfg.copy()
+        profile_cfg["outputs"]["test"]["attach"] = [
+            {
+                "alias": "lk_db",
+                "path": "/path/to/regular.db",
+                "type": "ducklake",
+            }
+        ]
+
+        adapter = self._get_adapter(profile_cfg)
+        relation = DuckDBRelation.create(database="lk_db", schema="test_schema", identifier="test_table")
+
+        result = adapter.is_ducklake(relation)
+
+        self.assertTrue(result)
+
+    def test_is_ducklake_with_type_ducklake_case_insensitive(self):
+        """Test is_ducklake handles mixed-case attachment type for ducklake."""
+        profile_cfg = self.base_profile_cfg.copy()
+        profile_cfg["outputs"]["test"]["attach"] = [
+            {
+                "alias": "lk_db2",
+                "path": "/path/to/another.db",
+                "type": "DuckLake",
+            }
+        ]
+
+        adapter = self._get_adapter(profile_cfg)
+        relation = DuckDBRelation.create(database="lk_db2", schema="test_schema", identifier="test_table")
+
+        result = adapter.is_ducklake(relation)
+
+        self.assertTrue(result)


### PR DESCRIPTION
Fixes Issue #619. The existing implementation of DuckLake support only works if if the `path` contains `ducklake:`, but MotherDuck managed DuckLake connects like a typical database. In order to support e.g. `DROP` operations, dbt must know if the underlying storage is DuckLake. Hence, this new type.