### PR TITLE
Display traceback when Python model raises exception

### DIFF
--- a/dbt/adapters/duckdb/environments/__init__.py
+++ b/dbt/adapters/duckdb/environments/__init__.py
@@ -289,7 +289,7 @@ class Environment(abc.ABC):
                 module.materialize(df, cur)
         except Exception as err:
             raise DbtRuntimeError(
-                f"Python model failed:\n" f"{"".join(traceback.format_exception(err))}"
+                f"Python model failed:\n" f"{''.join(traceback.format_exception(err))}"
             )
         finally:
             os.unlink(mod_file.name)


### PR DESCRIPTION
When a Python model errors, only the error message would be displayed, not the traceback. That makes it more difficult to debug more complicated Python models. This commit makes sure that the entire traceback gets displayed.