### PR TITLE
duckdb: fix dateadd interval syntax for newer DuckDB versions

### DIFF
--- a/dbt/include/duckdb/macros/utils/dateadd.sql
+++ b/dbt/include/duckdb/macros/utils/dateadd.sql
@@ -1,6 +1,22 @@
 {% macro duckdb__dateadd(datepart, interval, from_date_or_timestamp) %}
 
-    -- Use INTERVAL without parentheses for compatibility with newer DuckDB versions
-    date_add({{ from_date_or_timestamp }}, interval {{ interval }} {{ datepart }})
+    {#
+      Support both literal and expression intervals (e.g., column references)
+      by multiplying an INTERVAL by the value. This avoids DuckDB parser issues
+      with "interval (<expr>) <unit>" and works across versions.
+
+      Also map unsupported units:
+      - quarter => 3 months
+      - week    => 7 days (DuckDB supports WEEK as a literal, but keep it explicit)
+    #}
+
+    {%- set unit = datepart | lower -%}
+    {%- if unit == 'quarter' -%}
+        {{ from_date_or_timestamp }} + (cast({{ interval }} as bigint) * 3) * interval 1 month
+    {%- elif unit == 'week' -%}
+        {{ from_date_or_timestamp }} + (cast({{ interval }} as bigint) * 7) * interval 1 day
+    {%- else -%}
+        {{ from_date_or_timestamp }} + cast({{ interval }} as bigint) * interval 1 {{ unit }}
+    {%- endif -%}
 
 {% endmacro %}

--- a/dbt/include/duckdb/macros/utils/dateadd.sql
+++ b/dbt/include/duckdb/macros/utils/dateadd.sql
@@ -12,11 +12,11 @@
 
     {%- set unit = datepart | lower -%}
     {%- if unit == 'quarter' -%}
-        {{ from_date_or_timestamp }} + (cast({{ interval }} as bigint) * 3) * interval 1 month
+        ({{ from_date_or_timestamp }} + (cast({{ interval }} as bigint) * 3) * interval 1 month)
     {%- elif unit == 'week' -%}
-        {{ from_date_or_timestamp }} + (cast({{ interval }} as bigint) * 7) * interval 1 day
+        ({{ from_date_or_timestamp }} + (cast({{ interval }} as bigint) * 7) * interval 1 day)
     {%- else -%}
-        {{ from_date_or_timestamp }} + cast({{ interval }} as bigint) * interval 1 {{ unit }}
+        ({{ from_date_or_timestamp }} + cast({{ interval }} as bigint) * interval 1 {{ unit }})
     {%- endif -%}
 
 {% endmacro %}

--- a/dbt/include/duckdb/macros/utils/dateadd.sql
+++ b/dbt/include/duckdb/macros/utils/dateadd.sql
@@ -1,5 +1,6 @@
 {% macro duckdb__dateadd(datepart, interval, from_date_or_timestamp) %}
 
-    date_add({{ from_date_or_timestamp }}, interval ({{ interval }}) {{ datepart }})
+    -- Use INTERVAL without parentheses for compatibility with newer DuckDB versions
+    date_add({{ from_date_or_timestamp }}, interval {{ interval }} {{ datepart }})
 
 {% endmacro %}


### PR DESCRIPTION
This updates the DuckDB dateadd macro to use the standard `INTERVAL <n> <unit>` form rather than `interval (<n>) <unit>`. In upcoming DuckDB releases the parenthesized literal form can raise:\n\n> Not implemented Error: Unimplemented expression class\n\nThis change keeps date_spine/dbt_utils flows working on nightly and remains compatible with current stable releases.