### PR TITLE
Remove extraneous log() lines for index-related operations

### DIFF
--- a/dbt/include/duckdb/macros/adapters.sql
+++ b/dbt/include/duckdb/macros/adapters.sql
@@ -263,7 +263,6 @@ def materialize(df, con):
 {%- endmacro %}
 
 {% macro drop_indexes_on_relation(relation) -%}
-  {{ log("Dropping indexes on relation " ~ relation, info=true) }}
   {% call statement('get_indexes_on_relation', fetch_result=True) %}
     SELECT index_name
     FROM duckdb_indexes()
@@ -272,14 +271,11 @@ def materialize(df, con):
   {% endcall %}
 
   {% set results = load_result('get_indexes_on_relation').table %}
-  {{ log("Found " ~ results | length ~ " indexes to drop", info=true) }}
   {% for row in results %}
     {% set index_name = row[0] %}
-    {{ log("Dropping index: " ~ index_name, info=true) }}
     {% call statement('drop_index_' + loop.index|string, auto_begin=false) %}
       DROP INDEX "{{ relation.schema }}"."{{ index_name }}"
     {% endcall %}
-    {{ log("Index " ~ index_name ~ " drop statement executed", info=true) }}
   {% endfor %}
 
   {#-- Verify indexes were dropped --#}
@@ -290,5 +286,4 @@ def materialize(df, con):
       AND table_name = '{{ relation.identifier }}'
   {% endcall %}
   {% set verify_results = load_result('verify_indexes_dropped').table %}
-  {{ log("Remaining indexes after drop: " ~ verify_results[0][0], info=true) }}
 {%- endmacro %}


### PR DESCRIPTION
My bad here-- I thought the default logging threshold for dbt was higher than info, this adds ~ no value for most folks