### PR TITLE
Fix for attach test failures in nightly

### DIFF
--- a/tests/functional/adapter/test_attach.py
+++ b/tests/functional/adapter/test_attach.py
@@ -4,6 +4,7 @@ import tempfile
 import duckdb
 import pytest
 
+from dbt.adapters.duckdb import DuckDBConnectionManager
 from dbt.tests.util import run_dbt
 
 sources_schema_yml = """
@@ -74,6 +75,8 @@ class TestAttachedDatabase:
 
         test_results = run_dbt(["test"])
         assert len(test_results) == 2
+
+        DuckDBConnectionManager.close_all_connections()
 
         # check that the model is created in the attached db
         db = duckdb.connect(attach_test_db)


### PR DESCRIPTION
Was seeing these failures in the attach test in the nightly build: https://github.com/duckdb/dbt-duckdb/actions/runs/17567487839/job/49897168246

...and traced it to the fact that the dbt process running inside of the test was still holding a connection to the attached DB in 1.4.0-pre, so I got around it in the test case the same way we have other places (by adding a call to `DuckDBConnectionManager.close_all_connections()`

Noting that this is a testing issue and not an actual problem-- real dbt runs exit the python process when they are finished and let go of the attached DuckDB connections when they do

Verified the fix on my Linux dev box