### PR TITLE
Add slack notification on CI failure

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -486,3 +486,18 @@ jobs:
       - name: Check source distributions
         run: |
           dbt --version
+
+  notify-failure:
+    name: Send Slack notification on failure
+    if: failure() && github.ref == 'refs/heads/master'
+    needs: [code-quality, unit, functional, filebased, motherduck, buenavista, fsspec, plugins, build, test-build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Slack notification
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          webhook-url: ${{ secrets.MOTHERDUCK_CI_NOTIFICATION_WEBHOOK }}
+          payload: |
+            {
+              "text": "dbt-duckdb main workflow failed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -69,3 +69,18 @@ jobs:
         with:
           name: unit_results_${{ matrix.python-version }}-${{ steps.date.outputs.date }}.csv
           path: unit_results.csv
+
+  notify-failure:
+    name: Send Slack notification on failure
+    if: failure()
+    needs: [nightly]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Slack notification
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          webhook-url: ${{ secrets.MOTHERDUCK_CI_NOTIFICATION_WEBHOOK }}
+          payload: |
+            {
+              "text": "dbt-duckdb nightly workflow failed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,3 +95,18 @@ jobs:
         gh release upload
         '${{ github.ref_name }}' dist/**
         --repo '${{ github.repository }}'
+
+  notify-failure:
+    name: Send Slack notification on failure
+    if: failure()
+    needs: [build, publish-to-pypi, github-release]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Slack notification
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          webhook-url: ${{ secrets.MOTHERDUCK_CI_NOTIFICATION_WEBHOOK }}
+          payload: |
+            {
+              "text": "dbt-duckdb release workflow failed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }


### PR DESCRIPTION
Email continues to be a hard thing for github actions to do, so slack it is.