### PR TITLE
feat(duckdb): add MERGE and microbatch support for incremental strategies

### DIFF
--- a/dbt/include/duckdb/macros/incremental_helper.sql
+++ b/dbt/include/duckdb/macros/incremental_helper.sql
@@ -40,3 +40,65 @@
     )
 
 {%- endmacro %}
+
+
+{% macro duckdb__get_incremental_microbatch_sql(arg_dict) -%}
+    {#-- Microbatch strategy uses delete+insert for DuckDB --#}
+    {#-- This works efficiently for time-based batch processing --#}
+    {% do return(duckdb__get_delete_insert_merge_sql(
+        arg_dict["target_relation"],
+        arg_dict["temp_relation"],
+        arg_dict["unique_key"],
+        arg_dict["dest_columns"],
+        arg_dict["incremental_predicates"]
+    )) %}
+{%- endmacro %}
+
+
+{% macro duckdb__get_merge_sql(target, source, unique_key, dest_columns, incremental_predicates) -%}
+    {#-- DuckDB 1.4.0+ supports MERGE INTO statements --#}
+    {%- set predicates = [] if incremental_predicates is none else [] + incremental_predicates -%}
+    {%- set dest_cols_csv = get_quoted_csv(dest_columns | map(attribute="name")) -%}
+    {%- set merge_update_columns = config.get('merge_update_columns') -%}
+    {%- set merge_exclude_columns = config.get('merge_exclude_columns') -%}
+    {%- set update_columns = get_merge_update_columns(merge_update_columns, merge_exclude_columns, dest_columns) -%}
+    {%- set sql_header = config.get('sql_header', none) -%}
+
+    {% if unique_key %}
+        {% if unique_key is sequence and unique_key is not mapping and unique_key is not string %}
+            {% for key in unique_key %}
+                {% set this_key_match %}
+                    DBT_INTERNAL_SOURCE.{{ key }} = DBT_INTERNAL_DEST.{{ key }}
+                {% endset %}
+                {% do predicates.append(this_key_match) %}
+            {% endfor %}
+        {% else %}
+            {% set unique_key_match %}
+                DBT_INTERNAL_SOURCE.{{ unique_key }} = DBT_INTERNAL_DEST.{{ unique_key }}
+            {% endset %}
+            {% do predicates.append(unique_key_match) %}
+        {% endif %}
+    {% else %}
+        {% do predicates.append('FALSE') %}
+    {% endif %}
+
+    {{ sql_header if sql_header is not none }}
+
+    merge into {{ target }} as DBT_INTERNAL_DEST
+        using {{ source }} as DBT_INTERNAL_SOURCE
+        on {{ "(" ~ predicates | join(") and (") ~ ")" }}
+
+    {% if unique_key %}
+    when matched then update set
+        {% for column_name in update_columns -%}
+            {{ column_name }} = DBT_INTERNAL_SOURCE.{{ column_name }}
+            {%- if not loop.last %}, {%- endif %}
+        {%- endfor %}
+    {% endif %}
+
+    when not matched then insert
+        ({{ dest_cols_csv }})
+    values
+        ({{ dest_cols_csv }})
+
+{%- endmacro %}


### PR DESCRIPTION
Added version-aware support for MERGE statements in DuckDB adapter for versions 1.4.0 and above. Introduced `_supports_merge` property to check and cache version compatibility, enabling "merge" and "microbatch" incremental strategies alongside existing "append" and "delete+insert". Updated SQL macros to implement microbatch and merge logic for efficient batch processing and upserts.