### PR TITLE
fix(table): ducklake needs extra commit betwen 2 alter table rename

### DIFF
--- a/dbt/include/duckdb/macros/materializations/table.sql
+++ b/dbt/include/duckdb/macros/materializations/table.sql
@@ -37,7 +37,10 @@
   {% if existing_relation is not none %}
       {#-- Drop indexes before renaming to avoid dependency errors --#}
       {% do drop_indexes_on_relation(existing_relation) %}
-      {{ drop_relation_if_exists(existing_relation) }}
+      {{ adapter.rename_relation(existing_relation, backup_relation) }}
+      {% if adapter.is_ducklake(target_relation) %}
+        {{ adapter.commit() }}
+      {% endif %}
   {% endif %}
 
   {{ adapter.rename_relation(intermediate_relation, target_relation) }}


### PR DESCRIPTION
cf. issue #646
otherwise, we had an error on `dbt build -s my_table` on 2nd run (drop / create table)
and we already did a backup on [line 16
](https://github.com/duckdb/dbt-duckdb/blob/e7ea27b321d4a904478ba913b5eb67b715c2b308/dbt/include/duckdb/macros/materializations/table.sql#L16)
```log
08:05:32    Runtime Error in model stg_commande (models/hypermarche/stg/stg_commande.sql)
  Binder Error: Cannot rename table stg_commande__dbt_tmp to stg_commande, since stg_commande__dbt_tmp already exists.
```