### PR TITLE
Drop support for Python 3.8 and 3.9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,7 +73,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
 
     env:
       TOXENV: "unit"
@@ -118,7 +118,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
 
     env:
       TOXENV: "functional"
@@ -166,7 +166,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
 
     env:
       TOXENV: "filebased"
@@ -322,7 +322,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9']
+        python-version: ['3.10']
 
     env:
       TOXENV: "fsspec"
@@ -454,7 +454,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
 
     steps:
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
 
     env:
       TOXENV: "nightly"

--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ Please remember that using plugins may require you to add additional dependencie
 
 * `excel` depends on `pandas`, and `openpyxl` or `xlsxwriter` to perform writes
 * `gsheet` depends on `gspread` and `pandas`
-*  `iceberg` depends on `pyiceberg` and Python >= 3.8
+* `iceberg` depends on `pyiceberg` and Python >= 3.10
 * `sqlalchemy` depends on `pandas`, `sqlalchemy`, and the driver(s) you need
 
 **Experimental:**

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,6 @@ classifier =
     Operating System :: Microsoft :: Windows
     Operating System :: MacOS :: MacOS X
     Operating System :: POSIX :: Linux
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
@@ -29,7 +28,7 @@ install_requires=
     duckdb>=1.0.0
     # add dbt-core to ensure backwards compatibility of installation, this is not a functional dependency
     dbt-core>=1.8.0
-python_requires = >=3.9
+python_requires = >=3.10
 include_package_data = True
 packages = find_namespace:
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 skipsdist = True
-envlist = py{38,39,310,311,312,313}
+envlist = py{310,311,312,313}
 
-[testenv:{unit,py38,py39,py310,py311,py312,py313,py}]
+[testenv:{unit,py310,py311,py312,py313,py}]
 description = unit testing
 skip_install = True
 passenv = *
@@ -11,7 +11,7 @@ deps =
   -rdev-requirements.txt
   -e.
 
-[testenv:{functional,py38,py39,py310,py311,py312,py313,py}]
+[testenv:{functional,py310,py311,py312,py313,py}]
 description = adapter functional testing
 skip_install = True
 passenv = *
@@ -20,7 +20,7 @@ deps =
   -rdev-requirements.txt
   -e.
 
-[testenv:{filebased,py38,py39,py310,py311,py312,py313,py}]
+[testenv:{filebased,py310,py311,py312,py313,py}]
 description = adapter functional testing using file-based DBs
 skip_install = True
 passenv = *
@@ -29,7 +29,7 @@ deps =
   -rdev-requirements.txt
   -e.
 
-[testenv:{buenavista,py39}]
+[testenv:{buenavista,py310}]
 description = adapter functional testing using a Buena Vista server
 skip_install = True
 passenv = *
@@ -47,7 +47,7 @@ deps =
   -rdev-requirements.txt
   -e.[md]
 
-[testenv:{fsspec,py38,py39,py310,py311,py312,py313,py}]
+[testenv:{fsspec,py310,py311,py312,py313,py}]
 description = adapter fsspec testing
 skip_install = True
 passenv = *
@@ -56,7 +56,7 @@ deps =
   -rdev-requirements.txt
   -e.
 
-[testenv:{plugins,py38,py39,py310,py311,py312,py313,py}]
+[testenv:{plugins,py310,py311,py312,py313,py}]
 description = adapter plugin testing
 skip_install = True
 passenv = *
@@ -65,7 +65,7 @@ deps =
   -rdev-requirements.txt
   -e.
 
-[testenv:{nightly,py38,py39,py310,py311,py312,py313,py}]
+[testenv:{nightly,py310,py311,py312,py313,py}]
 description = duckdb nightly release testing
 skip_install = True
 passenv = *


### PR DESCRIPTION
## Summary
- drop Python 3.8/3.9 from packaging metadata and docs
- update tox environments and CI matrices to require Python 3.10+

## Testing
- not run (configuration changes only)
