### PR TITLE
Bump md duckdb to 1.4.2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ glue =
     boto3
     mypy-boto3-glue
 md =
-    duckdb==1.4.1
+    duckdb==1.4.2
 
 [files]
 packages =


### PR DESCRIPTION
The 1.4.2 duckdb [release](https://github.com/duckdb/duckdb/releases/tag/v1.4.2) included more support for Iceberg operations (by bringing in [this](https://github.com/duckdb/duckdb-iceberg/commit/5e22d03133f98ce6062ef6df10355eff037ef23b) iceberg extension commit), which would be great to have access to.  This bumps the version in the `md` section, and since the regular dependency is `duckdb>=1.0.0`, a new build will bring in 1.4.2, which was [released recently](https://github.com/duckdb/duckdb-python/releases/tag/v1.4.2).

I got a couple unit test failures, but they happen on a fresh checkout, so it's probably something to do with my env:

> ERROR tests/functional/plugins/motherduck/test_motherduck.py::test_motherduck_user_agent - KeyError: 'path'
> ERROR tests/functional/plugins/test_plugins.py::TestPlugins::test_plugins - sqlite3.OperationalError: table tt1 already exists

Hey @jwills 👋  - when do you think a new dbt-duckdb release can happen?  Thanks.