### PR TITLE
Log duckdb Error Message

### DIFF
--- a/dbt/adapters/duckdb/connections.py
+++ b/dbt/adapters/duckdb/connections.py
@@ -101,6 +101,7 @@ class DuckDBConnectionManager(SQLConnectionManager):
             # Preserve original RuntimeError with full context instead of swallowing
             raise dbt.exceptions.DbtRuntimeError(str(e)) from e
         except Exception as exc:
+            logger.debug("duckdb error: {}".format(str(exc)))
             logger.debug("Error running SQL: {}".format(sql))
             logger.debug("Rolling back transaction.")
             raise dbt.exceptions.DbtRuntimeError(str(exc)) from exc


### PR DESCRIPTION
A very small PR on the exception handler as people have reported not being able to see DuckDB error messages. (MotherDuck Support)

Details:
The `exception_handler` logs errors for `RuntimeError` but not for other exceptions. I'm adding error logging there to be consistent with the `RuntimeError` handler.

Some reasons of the top of my head on why error messages need to be preserved with full context:
1. The error message is hard to find (buried in logs)
2. It's separated from the SQL that caused it
3. You have to manually correlate "Error running SQL: COMMIT" with the error message that appears much later in the logs