### PR TITLE
Fix transaction commit error when no upstream external models exist (Fixes #678)

### DIFF
--- a/dbt/include/duckdb/macros/utils/upstream.sql
+++ b/dbt/include/duckdb/macros/utils/upstream.sql
@@ -35,7 +35,7 @@
     {% endif %}
   {% endfor %}
 {% endfor %}
-{% if upstream_nodes %}
+{% if upstream_schemas %}
   {% do adapter.commit() %}
 {% endif %}
 {% endif %}


### PR DESCRIPTION
This PR fixes a bug introduced in 1.9.4 where executing models without upstream external models causes a transaction commit error.

## Problem
When using `register_upstream_external_models()` in `on-run-start`, Dagster runs fail with:
```
Tried to commit transaction on connection "master", but it does not have one open!
```

This occurs because `upstream_nodes` is populated before checking if nodes are external, so the commit check triggers even when no external models are processed.

## Solution
Change the commit condition from `upstream_nodes` to `upstream_schemas`. Since `upstream_schemas` is only populated when schemas are actually created for external models, this ensures we only commit when work has been done that requires a commit.

## Testing
- Verified fix works for models without upstream external models
- Verified fix works for models with upstream external models

Fixes #678