### PR TITLE
fix: rollback transaction in exception handler

### DIFF
--- a/dbt/adapters/duckdb/connections.py
+++ b/dbt/adapters/duckdb/connections.py
@@ -95,18 +95,12 @@ class DuckDBConnectionManager(SQLConnectionManager):
             yield
         except dbt.exceptions.DbtRuntimeError:
             raise
-        except RuntimeError as e:
+        except (RuntimeError, Exception) as e:
             logger.debug("duckdb error: {}".format(str(e)))
             logger.debug("Error running SQL: {}".format(sql))
             logger.debug("Rolling back transaction.")
             self.rollback_if_open()
             raise dbt.exceptions.DbtRuntimeError(str(e)) from e
-        except Exception as exc:
-            logger.debug("duckdb error: {}".format(str(exc)))
-            logger.debug("Error running SQL: {}".format(sql))
-            logger.debug("Rolling back transaction.")
-            self.rollback_if_open()
-            raise dbt.exceptions.DbtRuntimeError(str(exc)) from exc
 
     @classmethod
     def get_credentials(cls, credentials):


### PR DESCRIPTION
The exception handler logged "Rolling back transaction" but never executed the rollback, leaving transactions open after errors. This can cause open idle transactions.