### PR TITLE
pin pandas version for tests

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,7 +6,7 @@ dbt-tests-adapter==1.19.5
 
 boto3
 mypy-boto3-glue
-pandas
+pandas<3.0.0
 pyarrow==22.0.0
 buenavista==0.5.0
 bumpversion


### PR DESCRIPTION
with the latest pandas (3.0.0) some plugin tests are failing. 
```
FAILED tests/functional/plugins/test_excel.py::TestExcelPlugin::test_excel_plugin - _duckdb.NotImplementedException: Not implemented Error: Data type 'str' not recognized
FAILED tests/functional/plugins/test_plugins.py::TestPlugins::test_plugins - _duckdb.NotImplementedException: Not implemented Error: Data type 'str' not recognized
ERROR tests/functional/plugins/test_plugins.py::TestPlugins::test_plugins - sqlite3.OperationalError: no such table: sqlalchemy2
```

there seems to be an issue in pandas. use the older version for tests for now.