### PR TITLE
fix(pre-commit): generalize pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ exclude: "^tests/.*"
 
 
 default_language_version:
-  python: python3.11
+  python: python3
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -41,10 +41,8 @@ repos:
   - id: mypy
     args: [--show-error-codes, --ignore-missing-imports]
     files: ^dbt/adapters/.*
-    language: system
   - id: mypy
     alias: mypy-check
     stages: [manual]
     args: [--show-error-codes, --pretty, --ignore-missing-imports]
     files: ^dbt/adapters
-    language: system

--- a/README.md
+++ b/README.md
@@ -215,7 +215,6 @@ attach:
     is_ducklake: true
 ```
 
-
 The attached databases may be referred to in your dbt sources and models by either the basename of the database file minus its suffix (e.g., `/tmp/other.duckdb` is the `other` database
 and `s3://yep/even/this/works.duckdb` is the `works` database) or by an alias that you specify (so the `./yet/another.duckdb` database in the above configuration is referred to
 as `yet_another` instead of `another`.) Note that these additional databases do not necessarily have to be DuckDB files: DuckDB's storage and catalog engines are pluggable, and

--- a/dbt/adapters/duckdb/connections.py
+++ b/dbt/adapters/duckdb/connections.py
@@ -14,6 +14,7 @@ from dbt.adapters.contracts.connection import AdapterResponse
 from dbt.adapters.contracts.connection import Connection
 from dbt.adapters.contracts.connection import ConnectionState
 from dbt.adapters.events.logging import AdapterLogger
+from dbt.adapters.exceptions import FailedToConnectError
 from dbt.adapters.sql import SQLConnectionManager
 
 logger = AdapterLogger("DuckDB")
@@ -57,7 +58,7 @@ class DuckDBConnectionManager(SQLConnectionManager):
                 logger.debug("Got an error when attempting to connect to DuckDB: '{}'".format(e))
                 connection.handle = None
                 connection.state = ConnectionState.FAIL
-                raise dbt.adapters.exceptions.FailedToConnectError(str(e))
+                raise FailedToConnectError(str(e))
 
             return connection
 

--- a/dbt/adapters/duckdb/impl.py
+++ b/dbt/adapters/duckdb/impl.py
@@ -118,7 +118,9 @@ class DuckDBAdapter(SQLAdapter):
 
     # can be overridden via the model config metadata
     _temp_schema_name = DEFAULT_TEMP_SCHEMA_NAME
-    _temp_schema_model_uuid: dict[str, str] = defaultdict(lambda: str(uuid4()).split("-")[-1])
+    _temp_schema_model_uuid: dict[str, str] = defaultdict(
+        lambda: str(uuid4()).split("-")[-1]
+    )
 
     @classmethod
     def date_function(cls) -> str:
@@ -180,7 +182,9 @@ class DuckDBAdapter(SQLAdapter):
                     [
                         (
                             column.name,
-                            agate.Formula(agate.Text(), lambda row: str(row[column.name])),
+                            agate.Formula(
+                                agate.Text(), lambda row: str(row[column.name])
+                            ),
                         )
                     ],
                     replace=True,
@@ -230,7 +234,9 @@ class DuckDBAdapter(SQLAdapter):
         return DuckDBConnectionManager.env().get_binding_char()
 
     @available
-    def external_write_options(self, write_location: str, rendered_options: dict) -> str:
+    def external_write_options(
+        self, write_location: str, rendered_options: dict
+    ) -> str:
         if "format" not in rendered_options:
             ext = os.path.splitext(write_location)[1].lower()
             if ext:
@@ -263,13 +269,19 @@ class DuckDBAdapter(SQLAdapter):
         return ", ".join(ret)
 
     @available
-    def external_read_location(self, write_location: str, rendered_options: dict) -> str:
-        if rendered_options.get("partition_by") or rendered_options.get("per_thread_output"):
+    def external_read_location(
+        self, write_location: str, rendered_options: dict
+    ) -> str:
+        if rendered_options.get("partition_by") or rendered_options.get(
+            "per_thread_output"
+        ):
             globs = [write_location, "*"]
             if rendered_options.get("partition_by"):
                 partition_by = str(rendered_options.get("partition_by"))
                 globs.extend(["*"] * len(partition_by.split(",")))
-            return ".".join(["/".join(globs), str(rendered_options.get("format", "parquet"))])
+            return ".".join(
+                ["/".join(globs), str(rendered_options.get("format", "parquet"))]
+            )
         return write_location
 
     @available
@@ -323,11 +335,15 @@ class DuckDBAdapter(SQLAdapter):
             self.connections.commit_if_has_connection()
         except DbtInternalError as e:
             # Log commit errors instead of silently swallowing them to aid debugging
-            logger.warning(f"Commit failed with DbtInternalError: {e}\n{traceback.format_exc()}")
+            logger.warning(
+                f"Commit failed with DbtInternalError: {e}\n{traceback.format_exc()}"
+            )
             # Still pass to maintain backward compatibility, but now with visibility
             pass
 
-    def submit_python_job(self, parsed_model: dict, compiled_code: str) -> AdapterResponse:
+    def submit_python_job(
+        self, parsed_model: dict, compiled_code: str
+    ) -> AdapterResponse:
         connection = self.connections.get_if_exists()
         if not connection:
             connection = self.connections.get_thread_connection()
@@ -382,7 +398,9 @@ class DuckDBAdapter(SQLAdapter):
         return flattened_columns
 
     @classmethod
-    def render_column_constraint(cls, constraint: ColumnLevelConstraint) -> Optional[str]:
+    def render_column_constraint(
+        cls, constraint: ColumnLevelConstraint
+    ) -> Optional[str]:
         """Render the given constraint as DDL text. Should be overriden by adapters which need custom constraint
         rendering."""
         if constraint.type == ConstraintType.foreign_key:
@@ -394,7 +412,9 @@ class DuckDBAdapter(SQLAdapter):
                     constraint_to = ".".join(pieces[1:])
                 else:
                     constraint_to = constraint.to
-                return f"references {constraint_to} ({', '.join(constraint.to_columns)})"
+                return (
+                    f"references {constraint_to} ({', '.join(constraint.to_columns)})"
+                )
             else:
                 return f"references {constraint.expression}"
         else:

--- a/dbt/adapters/duckdb/impl.py
+++ b/dbt/adapters/duckdb/impl.py
@@ -118,9 +118,7 @@ class DuckDBAdapter(SQLAdapter):
 
     # can be overridden via the model config metadata
     _temp_schema_name = DEFAULT_TEMP_SCHEMA_NAME
-    _temp_schema_model_uuid: dict[str, str] = defaultdict(
-        lambda: str(uuid4()).split("-")[-1]
-    )
+    _temp_schema_model_uuid: dict[str, str] = defaultdict(lambda: str(uuid4()).split("-")[-1])
 
     @classmethod
     def date_function(cls) -> str:
@@ -182,9 +180,7 @@ class DuckDBAdapter(SQLAdapter):
                     [
                         (
                             column.name,
-                            agate.Formula(
-                                agate.Text(), lambda row: str(row[column.name])
-                            ),
+                            agate.Formula(agate.Text(), lambda row: str(row[column.name])),
                         )
                     ],
                     replace=True,
@@ -234,9 +230,7 @@ class DuckDBAdapter(SQLAdapter):
         return DuckDBConnectionManager.env().get_binding_char()
 
     @available
-    def external_write_options(
-        self, write_location: str, rendered_options: dict
-    ) -> str:
+    def external_write_options(self, write_location: str, rendered_options: dict) -> str:
         if "format" not in rendered_options:
             ext = os.path.splitext(write_location)[1].lower()
             if ext:
@@ -269,19 +263,13 @@ class DuckDBAdapter(SQLAdapter):
         return ", ".join(ret)
 
     @available
-    def external_read_location(
-        self, write_location: str, rendered_options: dict
-    ) -> str:
-        if rendered_options.get("partition_by") or rendered_options.get(
-            "per_thread_output"
-        ):
+    def external_read_location(self, write_location: str, rendered_options: dict) -> str:
+        if rendered_options.get("partition_by") or rendered_options.get("per_thread_output"):
             globs = [write_location, "*"]
             if rendered_options.get("partition_by"):
                 partition_by = str(rendered_options.get("partition_by"))
                 globs.extend(["*"] * len(partition_by.split(",")))
-            return ".".join(
-                ["/".join(globs), str(rendered_options.get("format", "parquet"))]
-            )
+            return ".".join(["/".join(globs), str(rendered_options.get("format", "parquet"))])
         return write_location
 
     @available
@@ -335,15 +323,11 @@ class DuckDBAdapter(SQLAdapter):
             self.connections.commit_if_has_connection()
         except DbtInternalError as e:
             # Log commit errors instead of silently swallowing them to aid debugging
-            logger.warning(
-                f"Commit failed with DbtInternalError: {e}\n{traceback.format_exc()}"
-            )
+            logger.warning(f"Commit failed with DbtInternalError: {e}\n{traceback.format_exc()}")
             # Still pass to maintain backward compatibility, but now with visibility
             pass
 
-    def submit_python_job(
-        self, parsed_model: dict, compiled_code: str
-    ) -> AdapterResponse:
+    def submit_python_job(self, parsed_model: dict, compiled_code: str) -> AdapterResponse:
         connection = self.connections.get_if_exists()
         if not connection:
             connection = self.connections.get_thread_connection()
@@ -398,9 +382,7 @@ class DuckDBAdapter(SQLAdapter):
         return flattened_columns
 
     @classmethod
-    def render_column_constraint(
-        cls, constraint: ColumnLevelConstraint
-    ) -> Optional[str]:
+    def render_column_constraint(cls, constraint: ColumnLevelConstraint) -> Optional[str]:
         """Render the given constraint as DDL text. Should be overriden by adapters which need custom constraint
         rendering."""
         if constraint.type == ConstraintType.foreign_key:
@@ -412,9 +394,7 @@ class DuckDBAdapter(SQLAdapter):
                     constraint_to = ".".join(pieces[1:])
                 else:
                     constraint_to = constraint.to
-                return (
-                    f"references {constraint_to} ({', '.join(constraint.to_columns)})"
-                )
+                return f"references {constraint_to} ({', '.join(constraint.to_columns)})"
             else:
                 return f"references {constraint.expression}"
         else:

--- a/dbt/adapters/duckdb/impl.py
+++ b/dbt/adapters/duckdb/impl.py
@@ -152,6 +152,23 @@ class DuckDBAdapter(SQLAdapter):
         return relation.database in self.config.credentials._ducklake_dbs
 
     @available
+    def persist_docs_inside_transaction(self, relation: DuckDBRelation, persist_docs: dict[str, Any]) -> bool:
+        if "transaction" in persist_docs:
+            return persist_docs["transaction"]
+
+        # Preserve the branch's current compatibility behavior until DuckLake
+        # comment operations can safely move back into the main transaction.
+        return not self.is_ducklake(relation)
+
+    @available
+    def is_transaction_open(self) -> bool:
+        connection = self.connections.get_if_exists()
+        if connection is None:
+            return False
+
+        return connection.transaction_open
+
+    @available
     def convert_datetimes_to_strs(self, table: "agate.Table") -> "agate.Table":
         import agate
 

--- a/dbt/adapters/duckdb/impl.py
+++ b/dbt/adapters/duckdb/impl.py
@@ -152,7 +152,9 @@ class DuckDBAdapter(SQLAdapter):
         return relation.database in self.config.credentials._ducklake_dbs
 
     @available
-    def persist_docs_inside_transaction(self, relation: DuckDBRelation, persist_docs: dict[str, Any]) -> bool:
+    def persist_docs_inside_transaction(
+        self, relation: DuckDBRelation, persist_docs: dict[str, Any]
+    ) -> bool:
         if "transaction" in persist_docs:
             return persist_docs["transaction"]
 

--- a/dbt/include/duckdb/macros/materializations/incremental.sql
+++ b/dbt/include/duckdb/macros/materializations/incremental.sql
@@ -103,12 +103,14 @@
     {% do create_indexes(target_relation) %}
   {% endif %}
 
-  {% do persist_docs(target_relation, model) %}
+  {% do duckdb_run_persist_docs(target_relation, model, inside_transaction=True) %}
 
   {{ run_hooks(post_hooks, inside_transaction=True) }}
 
   -- `COMMIT` happens here
   {% do adapter.commit() %}
+
+  {% do duckdb_run_persist_docs(target_relation, model, inside_transaction=False) %}
 
   {% for rel in to_drop %}
       {# On MotherDuck the temp relation is a real table; dropping it cascades indexes. Avoid extra ALTERs. #}

--- a/dbt/include/duckdb/macros/materializations/seed.sql
+++ b/dbt/include/duckdb/macros/materializations/seed.sql
@@ -1,0 +1,65 @@
+{% materialization seed, adapter='duckdb' %}
+  {# DuckDB override of the default seed materialization so persist_docs can honor
+     the adapter-specific transaction routing used for DuckLake. #}
+
+  {%- set identifier = model['alias'] -%}
+  {%- set full_refresh_mode = (should_full_refresh()) -%}
+
+  {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}
+
+  {%- set exists_as_table = (old_relation is not none and old_relation.is_table) -%}
+  {%- set exists_as_view = (old_relation is not none and old_relation.is_view) -%}
+
+  {%- set grant_config = config.get('grants') -%}
+  {%- set agate_table = load_agate_table() -%}
+
+  {%- do store_result('agate_table', response='OK', agate_table=agate_table) -%}
+
+  {{ run_hooks(pre_hooks, inside_transaction=False) }}
+
+  -- `BEGIN` happens here:
+  {{ run_hooks(pre_hooks, inside_transaction=True) }}
+
+  -- build model
+  {% set create_table_sql = "" %}
+  {% if exists_as_view %}
+    {{ exceptions.raise_compiler_error("Cannot seed to '{}', it is a view".format(old_relation.render())) }}
+  {% elif exists_as_table %}
+    {% set create_table_sql = reset_csv_table(model, full_refresh_mode, old_relation, agate_table) %}
+  {% else %}
+    {% set create_table_sql = create_csv_table(model, agate_table) %}
+  {% endif %}
+
+  {% set code = 'CREATE' if full_refresh_mode else 'INSERT' %}
+  {% set rows_affected = (agate_table.rows | length) %}
+  {% set sql = load_csv_rows(model, agate_table) %}
+
+  {% call noop_statement('main', code ~ ' ' ~ rows_affected, code, rows_affected) %}
+    {{ get_csv_sql(create_table_sql, sql) }};
+  {% endcall %}
+
+  {% set target_relation = this.incorporate(type='table') %}
+
+  {% set should_revoke = should_revoke(old_relation, full_refresh_mode) %}
+  {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
+
+  {# Diverges from dbt-core: persist_docs may need to run after commit. #}
+  {% do duckdb_run_persist_docs(target_relation, model, inside_transaction=True) %}
+
+  {% if full_refresh_mode or not exists_as_table %}
+    {% do create_indexes(target_relation) %}
+  {% endif %}
+
+  {{ run_hooks(post_hooks, inside_transaction=True) }}
+
+  -- `COMMIT` happens here
+  {{ adapter.commit() }}
+
+  {# Diverges from dbt-core: run the post-commit persist_docs branch when requested. #}
+  {% do duckdb_run_persist_docs(target_relation, model, inside_transaction=False) %}
+
+  {{ run_hooks(post_hooks, inside_transaction=False) }}
+
+  {{ return({'relations': [target_relation]}) }}
+
+{% endmaterialization %}

--- a/dbt/include/duckdb/macros/materializations/snapshot.sql
+++ b/dbt/include/duckdb/macros/materializations/snapshot.sql
@@ -1,0 +1,105 @@
+{% materialization snapshot, adapter='duckdb' %}
+  {# DuckDB override of the default snapshot materialization so persist_docs can
+     honor the adapter-specific transaction routing used for DuckLake. #}
+
+  {%- set target_table = model.get('alias', model.get('name')) -%}
+
+  {%- set strategy_name = config.get('strategy') -%}
+  {%- set unique_key = config.get('unique_key') %}
+  {%- set grant_config = config.get('grants') -%}
+
+  {% set target_relation_exists, target_relation = get_or_create_relation(
+          database=model.database,
+          schema=model.schema,
+          identifier=target_table,
+          type='table') -%}
+
+  {%- if not target_relation.is_table -%}
+    {% do exceptions.relation_wrong_type(target_relation, 'table') %}
+  {%- endif -%}
+
+  {{ run_hooks(pre_hooks, inside_transaction=False) }}
+
+  {{ run_hooks(pre_hooks, inside_transaction=True) }}
+
+  {% set strategy_macro = strategy_dispatch(strategy_name) %}
+  {% set strategy = strategy_macro(model, "snapshotted_data", "source_data", model['config'], target_relation_exists) %}
+
+  {% if not target_relation_exists %}
+      {% set build_sql = build_snapshot_table(strategy, model['compiled_code']) %}
+      {% set build_or_select_sql = build_sql %}
+      {% set final_sql = create_table_as(False, target_relation, build_sql) %}
+  {% else %}
+      {% set columns = config.get("snapshot_table_column_names") or get_snapshot_table_column_names() %}
+
+      {{ adapter.assert_valid_snapshot_target_given_strategy(target_relation, columns, strategy) }}
+
+      {% set build_or_select_sql = snapshot_staging_table(strategy, sql, target_relation) %}
+      {% set staging_table = build_snapshot_staging_table(strategy, sql, target_relation) %}
+
+      {% do adapter.expand_target_column_types(from_relation=staging_table,
+                                               to_relation=target_relation) %}
+
+      {% set remove_columns = ['dbt_change_type', 'DBT_CHANGE_TYPE', 'dbt_unique_key', 'DBT_UNIQUE_KEY'] %}
+      {% if unique_key | is_list %}
+          {% for key in strategy.unique_key %}
+              {{ remove_columns.append('dbt_unique_key_' + loop.index|string) }}
+              {{ remove_columns.append('DBT_UNIQUE_KEY_' + loop.index|string) }}
+          {% endfor %}
+      {% endif %}
+
+      {% set missing_columns = adapter.get_missing_columns(staging_table, target_relation)
+                                   | rejectattr('name', 'in', remove_columns)
+                                   | list %}
+
+      {% do create_columns(target_relation, missing_columns) %}
+
+      {% set source_columns = adapter.get_columns_in_relation(staging_table)
+                                   | rejectattr('name', 'in', remove_columns)
+                                   | list %}
+
+      {% set quoted_source_columns = [] %}
+      {% for column in source_columns %}
+        {% do quoted_source_columns.append(adapter.quote(column.name)) %}
+      {% endfor %}
+
+      {% set final_sql = snapshot_merge_sql(
+            target = target_relation,
+            source = staging_table,
+            insert_cols = quoted_source_columns
+         )
+      %}
+  {% endif %}
+
+  {{ check_time_data_types(build_or_select_sql) }}
+
+  {% call statement('main') %}
+      {{ final_sql }}
+  {% endcall %}
+
+  {% set should_revoke = should_revoke(target_relation_exists, full_refresh_mode=False) %}
+  {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
+
+  {# Diverges from dbt-core: persist_docs may need to run after commit. #}
+  {% do duckdb_run_persist_docs(target_relation, model, inside_transaction=True) %}
+
+  {% if not target_relation_exists %}
+    {% do create_indexes(target_relation) %}
+  {% endif %}
+
+  {{ run_hooks(post_hooks, inside_transaction=True) }}
+
+  {{ adapter.commit() }}
+
+  {# Diverges from dbt-core: run the post-commit persist_docs branch when requested. #}
+  {% do duckdb_run_persist_docs(target_relation, model, inside_transaction=False) %}
+
+  {% if staging_table is defined %}
+      {% do post_snapshot(staging_table) %}
+  {% endif %}
+
+  {{ run_hooks(post_hooks, inside_transaction=False) }}
+
+  {{ return({'relations': [target_relation]}) }}
+
+{% endmaterialization %}

--- a/dbt/include/duckdb/macros/materializations/table.sql
+++ b/dbt/include/duckdb/macros/materializations/table.sql
@@ -16,6 +16,7 @@
   {%- set backup_relation = make_backup_relation(target_relation, backup_relation_type) -%}
   -- as above, the backup_relation should not already exist
   {%- set preexisting_backup_relation = load_cached_relation(backup_relation) -%}
+  {%- set post_commit_ducklake_docs = adapter.is_ducklake(target_relation) -%}
   -- grab current tables grants config for comparision later on
   {% set grant_config = config.get('grants') %}
 
@@ -48,11 +49,16 @@
 
   {% set should_revoke = should_revoke(existing_relation, full_refresh_mode=True) %}
   {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
-
-  {% do persist_docs(target_relation, model) %}
+  {% if not post_commit_ducklake_docs %}
+    {% do persist_docs(target_relation, model) %}
+  {% endif %}
 
   -- `COMMIT` happens here
   {{ adapter.commit() }}
+
+  {% if post_commit_ducklake_docs %}
+    {% do persist_docs(target_relation, model) %}
+  {% endif %}
 
   -- finally, drop the existing/backup relation after the commit
   {{ drop_relation_if_exists(backup_relation) }}

--- a/dbt/include/duckdb/macros/materializations/view.sql
+++ b/dbt/include/duckdb/macros/materializations/view.sql
@@ -1,64 +1,63 @@
-{% materialization table, adapter="duckdb", supported_languages=['sql', 'python'] %}
-
-  {%- set language = model['language'] -%}
+{%- materialization view, adapter='duckdb' -%}
+  {# DuckDB override of the default view materialization so persist_docs can honor
+     the adapter-specific transaction routing used for DuckLake. #}
 
   {%- set existing_relation = load_cached_relation(this) -%}
-  {%- set target_relation = this.incorporate(type='table') %}
+  {%- set target_relation = this.incorporate(type='view') -%}
   {%- set intermediate_relation =  make_intermediate_relation(target_relation) -%}
+
   -- the intermediate_relation should not already exist in the database; get_relation
   -- will return None in that case. Otherwise, we get a relation that we can drop
   -- later, before we try to use this name for the current operation
   {%- set preexisting_intermediate_relation = load_cached_relation(intermediate_relation) -%}
-  /*
-      See ../view/view.sql for more information about this relation.
-  */
-  {%- set backup_relation_type = 'table' if existing_relation is none else existing_relation.type -%}
+  {%- set backup_relation_type = 'view' if existing_relation is none else existing_relation.type -%}
   {%- set backup_relation = make_backup_relation(target_relation, backup_relation_type) -%}
   -- as above, the backup_relation should not already exist
   {%- set preexisting_backup_relation = load_cached_relation(backup_relation) -%}
   -- grab current tables grants config for comparision later on
   {% set grant_config = config.get('grants') %}
 
+  {{ run_hooks(pre_hooks, inside_transaction=False) }}
+
   -- drop the temp relations if they exist already in the database
   {{ drop_relation_if_exists(preexisting_intermediate_relation) }}
   {{ drop_relation_if_exists(preexisting_backup_relation) }}
-
-  {{ run_hooks(pre_hooks, inside_transaction=False) }}
 
   -- `BEGIN` happens here:
   {{ run_hooks(pre_hooks, inside_transaction=True) }}
 
   -- build model
-  {% call statement('main', language=language) -%}
-    {{- create_table_as(False, intermediate_relation, compiled_code, language) }}
+  {% call statement('main') -%}
+    {{ get_create_view_as_sql(intermediate_relation, sql) }}
   {%- endcall %}
 
   -- cleanup
+  -- move the existing view out of the way
   {% if existing_relation is not none %}
-      {#-- Drop indexes before renaming to avoid dependency errors --#}
-      {% do drop_indexes_on_relation(existing_relation) %}
-      {{ adapter.rename_relation(existing_relation, backup_relation) }}
+    {% set existing_relation = load_cached_relation(existing_relation) %}
+    {% if existing_relation is not none %}
+        {{ adapter.rename_relation(existing_relation, backup_relation) }}
+    {% endif %}
   {% endif %}
-
   {{ adapter.rename_relation(intermediate_relation, target_relation) }}
-
-  {% do create_indexes(target_relation) %}
-
-  {{ run_hooks(post_hooks, inside_transaction=True) }}
 
   {% set should_revoke = should_revoke(existing_relation, full_refresh_mode=True) %}
   {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
+
+  {# Diverges from dbt-core: persist_docs may need to run after commit. #}
   {% do duckdb_run_persist_docs(target_relation, model, inside_transaction=True) %}
 
-  -- `COMMIT` happens here
+  {{ run_hooks(post_hooks, inside_transaction=True) }}
+
   {{ adapter.commit() }}
 
+  {# Diverges from dbt-core: run the post-commit persist_docs branch when requested. #}
   {% do duckdb_run_persist_docs(target_relation, model, inside_transaction=False) %}
 
-  -- finally, drop the existing/backup relation after the commit
   {{ drop_relation_if_exists(backup_relation) }}
 
   {{ run_hooks(post_hooks, inside_transaction=False) }}
 
   {{ return({'relations': [target_relation]}) }}
-{% endmaterialization %}
+
+{%- endmaterialization -%}

--- a/dbt/include/duckdb/macros/persist_docs.sql
+++ b/dbt/include/duckdb/macros/persist_docs.sql
@@ -2,6 +2,18 @@
 {#
   The logic in this file is adapted from dbt-postgres, since DuckDB matches
   the Postgres relation/column commenting model as of 0.10.1
+
+  We intentionally diverge from the standard dbt/postgres persist_docs flow
+  to support DuckLake safely. DuckLake comment statements may need to run
+  after the model transaction commits, while the stock dbt persist_docs macro
+  assumes comments always execute inline and relies on helpers such as
+  run_query()/get_columns_in_relation() that can auto-open a transaction.
+
+  That auto-begin behavior is harmless for standard DuckDB models, but it
+  breaks the explicit post-commit path by silently re-entering a transaction.
+  The helper macros below therefore own both the transaction routing and the
+  post-commit column lookup so that `persist_docs.transaction: false` remains
+  truly outside the model transaction.
 #}
 
 {#
@@ -33,4 +45,97 @@
     {% set escaped_comment = duckdb_escape_comment(comment) %}
     comment on column {{ relation }}.{{ adapter.quote(column_name) if column_dict[column_name]['quote'] else column_name }} is {{ escaped_comment }};
   {% endfor %}
+{% endmacro %}
+
+{% macro duckdb_get_persist_docs_config(model) %}
+  {% set persist_docs = model.get('config', {}).get('persist_docs', {}) %}
+
+  {% if persist_docs is not mapping %}
+    {% do exceptions.raise_compiler_error(
+      "Invalid value provided for 'persist_docs'. Expected dict but received " ~ persist_docs.__class__.__name__
+    ) %}
+  {% endif %}
+
+  {% if 'transaction' in persist_docs and persist_docs['transaction'] is not boolean %}
+    {% do exceptions.raise_compiler_error(
+      "Invalid value provided for 'persist_docs.transaction'. Expected bool but received " ~ persist_docs['transaction']
+    ) %}
+  {% endif %}
+
+  {{ return(persist_docs) }}
+{% endmacro %}
+
+{% macro duckdb_persist_docs_inside_transaction(relation, model) %}
+  {% set persist_docs = duckdb_get_persist_docs_config(model) %}
+  {{ return(adapter.persist_docs_inside_transaction(relation, persist_docs)) }}
+{% endmacro %}
+
+{% macro duckdb_get_existing_column_names(relation, inside_transaction=True) %}
+  {% if inside_transaction %}
+    {{ return(adapter.get_columns_in_relation(relation) | map(attribute="name") | list) }}
+  {% endif %}
+
+  {#
+    Avoid adapter.get_columns_in_relation() here: the default dbt helper path
+    opens a transaction, which would pull the "outside transaction" docs flow
+    back into a transactional context and defeat the DuckLake workaround.
+  #}
+  {% call statement('duckdb_persist_docs_existing_columns', fetch_result=True, auto_begin=False) %}
+    select column_name
+    from system.information_schema.columns
+    where table_name = '{{ relation.identifier }}'
+      and lower(table_schema) = lower('{{ relation.schema }}')
+      {% if relation.database %}
+      and lower(table_catalog) = lower('{{ relation.database }}')
+      {% endif %}
+    order by ordinal_position
+  {% endcall %}
+
+  {{ return(load_result('duckdb_persist_docs_existing_columns').table.columns[0].values() | list) }}
+{% endmacro %}
+
+{% macro duckdb_validate_doc_columns(relation, column_dict, existing_column_names) %}
+  {% set existing_lower = existing_column_names | map("lower") | list %}
+  {% set missing = [] %}
+  {% for col_name in column_dict %}
+    {% if col_name | lower not in existing_lower %}
+      {% do missing.append(col_name) %}
+    {% endif %}
+  {% endfor %}
+  {% if missing | length > 0 %}
+    {{ exceptions.warn("In relation " ~ relation.render() ~ ": The following columns are specified in the schema but are not present in the database: " ~ missing | join(", ")) }}
+  {% endif %}
+  {% set filtered = {} %}
+  {% for col_name in column_dict if col_name | lower in existing_lower %}
+    {% do filtered.update({col_name: column_dict[col_name]}) %}
+  {% endfor %}
+  {{ return(filtered) }}
+{% endmacro %}
+
+{% macro duckdb_get_column_comment_sql(relation, column_name, column_config) %}
+  {% set escaped_comment = duckdb_escape_comment(column_config['description']) %}
+  comment on column {{ relation }}.{{ adapter.quote(column_name) if column_config['quote'] else column_name }} is {{ escaped_comment }};
+{% endmacro %}
+
+{% macro duckdb_run_persist_docs(relation, model, inside_transaction=True) %}
+  {% if duckdb_persist_docs_inside_transaction(relation, model) == inside_transaction %}
+    {% if config.persist_relation_docs() and model.description %}
+      {% call statement(auto_begin=inside_transaction) %}
+        {{ alter_relation_comment(relation, model.description) }}
+      {% endcall %}
+    {% endif %}
+
+    {% if config.persist_column_docs() and model.columns %}
+      {% set existing_columns = duckdb_get_existing_column_names(relation, inside_transaction) %}
+      {% set filtered_columns = duckdb_validate_doc_columns(relation, model.columns, existing_columns) %}
+      {% for column_name in filtered_columns %}
+        {% set alter_comment_sql = duckdb_get_column_comment_sql(relation, column_name, filtered_columns[column_name]) %}
+        {% if alter_comment_sql and alter_comment_sql | trim | length > 0 %}
+          {% call statement(auto_begin=inside_transaction) %}
+            {{ alter_comment_sql }}
+          {% endcall %}
+        {% endif %}
+      {% endfor %}
+    {% endif %}
+  {% endif %}
 {% endmacro %}

--- a/tests/functional/adapter/test_community_extensions.py
+++ b/tests/functional/adapter/test_community_extensions.py
@@ -12,15 +12,16 @@ class BaseCommunityExtensions:
 
     @pytest.fixture(scope="class")
     def dbt_profile_target(self, dbt_profile_target):
-        dbt_profile_target["extensions"] = [
-            {"name": "quack", "repo": "community"},
+        target = dbt_profile_target.copy()
+        target["extensions"] = [
+            {"name": "capi_quack", "repo": "community"},
         ]
-        return dbt_profile_target
+        return target
 
     @pytest.fixture(scope="class")
     def models(self):
         return {
-            "quack_model.sql": "select quack('world') as quack_world",
+            "quack_model.sql": "select multiply_numbers_together(6, 7) as quack_world",
         }
 
     @pytest.fixture(scope="class")

--- a/tests/functional/adapter/test_community_extensions.py
+++ b/tests/functional/adapter/test_community_extensions.py
@@ -12,16 +12,15 @@ class BaseCommunityExtensions:
 
     @pytest.fixture(scope="class")
     def dbt_profile_target(self, dbt_profile_target):
-        target = dbt_profile_target.copy()
-        target["extensions"] = [
-            {"name": "capi_quack", "repo": "community"},
+        dbt_profile_target["extensions"] = [
+            {"name": "quack", "repo": "community"},
         ]
-        return target
+        return dbt_profile_target
 
     @pytest.fixture(scope="class")
     def models(self):
         return {
-            "quack_model.sql": "select multiply_numbers_together(6, 7) as quack_world",
+            "quack_model.sql": "select quack('world') as quack_world",
         }
 
     @pytest.fixture(scope="class")

--- a/tests/functional/adapter/test_persist_docs.py
+++ b/tests/functional/adapter/test_persist_docs.py
@@ -12,6 +12,23 @@ class TestPersistDocs(BasePersistDocs):
 
 
 @pytest.mark.skip_profile("md")
+class TestPersistDocsTransactionFalse(BasePersistDocs):
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "models": {
+                "test": {
+                    "+persist_docs": {
+                        "relation": True,
+                        "columns": True,
+                        "transaction": False,
+                    },
+                }
+            }
+        }
+
+
+@pytest.mark.skip_profile("md")
 class TestPersistDocsColumnMissing(BasePersistDocsColumnMissing):
     pass
 

--- a/tests/functional/adapter/test_persist_docs_transaction_behavior.py
+++ b/tests/functional/adapter/test_persist_docs_transaction_behavior.py
@@ -1,0 +1,86 @@
+import uuid
+
+import pytest
+from dbt.tests.util import relation_from_name, run_dbt
+
+
+audit_table = f"persist_docs_audit_{uuid.uuid4().hex}"
+
+
+view_model_sql = """
+{{ config(materialized='view') }}
+select 1 as id, 'Joe' as name
+"""
+
+
+schema_yml = """
+version: 2
+
+models:
+  - name: view_model
+    description: "View model description"
+    columns:
+      - name: id
+        description: "id Column description"
+"""
+
+
+persist_docs_macros = f"""
+{{% macro duckdb__alter_relation_comment(relation, comment) %}}
+  insert into {audit_table}
+  values ('relation', {{{{ adapter.is_transaction_open() }}}})
+{{% endmacro %}}
+
+{{% macro duckdb__alter_column_comment(relation, column_dict) %}}
+  insert into {audit_table}
+  values ('column', {{{{ adapter.is_transaction_open() }}}})
+{{% endmacro %}}
+
+{{% macro duckdb_get_column_comment_sql(relation, column_name, column_config) %}}
+  insert into {audit_table}
+  values ('column', {{{{ adapter.is_transaction_open() }}}})
+{{% endmacro %}}
+"""
+
+
+@pytest.mark.skip_profile("md")
+class TestPersistDocsTransactionBehaviorView:
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "models": {
+                "test": {
+                    "+persist_docs": {
+                        "relation": True,
+                        "columns": True,
+                        "transaction": False,
+                    },
+                }
+            }
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"view_model.sql": view_model_sql}
+
+    @pytest.fixture(scope="class")
+    def properties(self):
+        return {"schema.yml": schema_yml}
+
+    @pytest.fixture(scope="class")
+    def macros(self):
+        return {"persist_docs_transaction_macros.sql": persist_docs_macros}
+
+    def test_view_persist_docs_runs_outside_transaction(self, project):
+        project.run_sql(f"create table {audit_table} (kind varchar, transaction_open boolean)")
+
+        run_dbt(["run"])
+
+        relation = relation_from_name(project.adapter, "view_model")
+        assert relation is not None
+
+        results = project.run_sql(
+            f"select kind, transaction_open from {audit_table} order by kind", fetch="all"
+        )
+
+        assert results == [("column", False), ("relation", False)]

--- a/tests/unit/test_duckdb_adapter.py
+++ b/tests/unit/test_duckdb_adapter.py
@@ -340,3 +340,50 @@ class TestDuckDBAdapterIsDucklake(unittest.TestCase):
         result = adapter.is_ducklake(relation)
         self.assertTrue(result)
 
+    def test_persist_docs_inside_transaction_defaults_true_for_non_ducklake(self):
+        adapter = self._get_adapter(self.base_profile_cfg)
+        relation = DuckDBRelation.create(database="regular_db", schema="test_schema", identifier="test_table")
+
+        result = adapter.persist_docs_inside_transaction(relation, {})
+
+        self.assertTrue(result)
+
+    def test_persist_docs_inside_transaction_defaults_false_for_ducklake(self):
+        profile_cfg = self.base_profile_cfg.copy()
+        profile_cfg["outputs"]["test"]["attach"] = [
+            {
+                "alias": "ducklake_db",
+                "path": "ducklake:sqlite:storage/metadata.sqlite"
+            }
+        ]
+
+        adapter = self._get_adapter(profile_cfg)
+        relation = DuckDBRelation.create(database="ducklake_db", schema="test_schema", identifier="test_table")
+
+        result = adapter.persist_docs_inside_transaction(relation, {})
+
+        self.assertFalse(result)
+
+    def test_persist_docs_inside_transaction_respects_explicit_true(self):
+        profile_cfg = self.base_profile_cfg.copy()
+        profile_cfg["outputs"]["test"]["attach"] = [
+            {
+                "alias": "ducklake_db",
+                "path": "ducklake:sqlite:storage/metadata.sqlite"
+            }
+        ]
+
+        adapter = self._get_adapter(profile_cfg)
+        relation = DuckDBRelation.create(database="ducklake_db", schema="test_schema", identifier="test_table")
+
+        result = adapter.persist_docs_inside_transaction(relation, {"transaction": True})
+
+        self.assertTrue(result)
+
+    def test_persist_docs_inside_transaction_respects_explicit_false(self):
+        adapter = self._get_adapter(self.base_profile_cfg)
+        relation = DuckDBRelation.create(database="regular_db", schema="test_schema", identifier="test_table")
+
+        result = adapter.persist_docs_inside_transaction(relation, {"transaction": False})
+
+        self.assertFalse(result)


### PR DESCRIPTION
The current pre-commit configuration was tied to specific settings (python and mypy hooks

- changes `default_language_version` from python3.11 to python3 using the generic working Python in the contributor's system
- removes `language: system` from the mypy hooks so pre-commit installs and runs its own pinned mypy