### PR TITLE
Skip ducklake tests when extension is not available

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ include =
 [tool:pytest]
 markers =
     with_s3_creds: marks tests that require S3 credentials
+    requires_ducklake: marks tests that require the ducklake extension
     skip_profile: marks tests to skip for a given profile type
 
 [build-system]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -120,7 +120,20 @@ def pytest_collection_modifyitems(config, items):
         if "Failed to download extension \"httpfs\"" in str(e):
             skip_s3 = pytest.mark.skip(reason="httpfs not available and is needed for setting s3 credentials")
 
+    # Skip ducklake tests if the extension is unavailable
+    skip_ducklake = None
+    try:
+        duckdb.sql("install ducklake")
+    except duckdb.Error as e:
+        if "Failed to download extension" in str(e):
+            skip_ducklake = pytest.mark.skip(reason="ducklake extension not available")
+
     if skip_s3 is not None:
         for item in items:
             if "with_s3_creds" in item.keywords:
                 item.add_marker(skip_s3)
+
+    if skip_ducklake is not None:
+        for item in items:
+            if "requires_ducklake" in item.keywords:
+                item.add_marker(skip_ducklake)

--- a/tests/functional/adapter/test_ducklake_partitioned_by_integration.py
+++ b/tests/functional/adapter/test_ducklake_partitioned_by_integration.py
@@ -101,6 +101,7 @@ def get_partition_columns(project, model_name, schema_name):
     return [row[0].lower() for row in project.run_sql(query, fetch="all")]
 
 
+@pytest.mark.requires_ducklake
 @pytest.mark.skip_profile("buenavista", "md")
 class BaseDucklakePartitionedBy:
     @pytest.fixture(scope="class")

--- a/tests/functional/adapter/test_persist_docs.py
+++ b/tests/functional/adapter/test_persist_docs.py
@@ -21,6 +21,7 @@ class TestPersistDocsColumnMissing(BasePersistDocsColumnMissing):
 class TestPersistDocsCommentOnQuotedColumn(BasePersistDocsCommentOnQuotedColumn):
     pass
 
+@pytest.mark.requires_ducklake
 @pytest.mark.skip_profile("md", "buenavista")
 class TestDuckLakePersistDocsTransactions:
     @pytest.fixture(scope="class")


### PR DESCRIPTION
## Summary
- Mirror the httpfs skip pattern from #714 for the ducklake extension: try to install it during test collection and skip `requires_ducklake`-marked tests when the download fails (e.g., nightly builds against a DuckDB build where the extension is not yet published).
- Add `@pytest.mark.requires_ducklake` to `BaseDucklakePartitionedBy` (covers `TestDucklakePartitionedByIntegration` and `TestPartitionedByValidation`) and `TestDuckLakePersistDocsTransactions`.
- Register the new marker in `setup.cfg`.

## Test plan
- [x] `PYTEST_ADDOPTS="-v -rfs" tox -e nightly` — ducklake tests should be skipped with a clear reason when the extension is unavailable
- [ ] `PYTEST_ADDOPTS="-v -rfs" tox` — ducklake tests should still execute and pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)