### PR TITLE
Revert "Fix single-threaded COPY in external materialization"

### DIFF
--- a/dbt/include/duckdb/macros/adapters.sql
+++ b/dbt/include/duckdb/macros/adapters.sql
@@ -284,7 +284,7 @@ def materialize(df, con):
 {% endmacro %}
 
 {% macro write_to_file(relation, location, options) -%}
-  {% call statement('write_to_file', auto_begin=False) -%}
+  {% call statement('write_to_file') -%}
     copy {{ relation }} to '{{ location }}' ({{ options }})
   {%- endcall %}
 {% endmacro %}

--- a/dbt/include/duckdb/macros/materializations/external.sql
+++ b/dbt/include/duckdb/macros/materializations/external.sql
@@ -76,15 +76,7 @@
     {% endif %}
   {%- endcall %}
 
-  -- Commit the transaction before COPY so DuckDB can use multi-threaded writes.
-  -- Without this, COPY inside a transaction is forced to use a single thread,
-  -- making PER_THREAD_OUTPUT and partition_by writes ineffective for large data.
-  -- See: https://github.com/duckdb/duckdb/issues/18074
-  {% if not adapter.disable_transactions() %}
-    {{ adapter.commit() }}
-  {% endif %}
-
-  -- write a temp relation into file (runs outside transaction for multi-threaded I/O)
+  -- write a temp relation into file
   {{ write_to_file(temp_relation, location, write_options) }}
 
 -- create a view on top of the location

--- a/tests/functional/adapter/test_write_options.py
+++ b/tests/functional/adapter/test_write_options.py
@@ -30,15 +30,10 @@ config_write_partition_by_id_name = """
     {{ config(materialized="external", options={"partition_by": "id, name"}) }}
 """
 
-config_write_per_thread_output = """
-    {{ config(materialized="external", options={"per_thread_output": "true"}) }}
-"""
-
 csv_delim_options_sql = config_write_csv_delim_options + model_base
 write_codec_options = config_write_codec_options + model_base
 config_write_partition_by_id_sql = config_write_partition_by_id + model_base
 config_write_partition_by_id_name_sql = config_write_partition_by_id_name + model_base
-config_write_per_thread_output_sql = config_write_per_thread_output + model_base
 
 
 class BaseExternalMaterializations:
@@ -58,7 +53,6 @@ class BaseExternalMaterializations:
             "write_codec_options.sql": write_codec_options,
             "config_write_partition_by_id.sql": config_write_partition_by_id_sql,
             "config_write_partition_by_id_name.sql": config_write_partition_by_id_name_sql,
-            "config_write_per_thread_output.sql": config_write_per_thread_output_sql,
             "schema.yml": schema_base_yml,
         }
 
@@ -84,7 +78,7 @@ class BaseExternalMaterializations:
         # run command
         results = run_dbt()
         # run result length
-        assert len(results) == 6
+        assert len(results) == 5
 
         # names exist in result nodes
         check_result_nodes_by_name(
@@ -95,7 +89,6 @@ class BaseExternalMaterializations:
                 "write_codec_options",
                 "config_write_partition_by_id",
                 "config_write_partition_by_id_name",
-                "config_write_per_thread_output",
             ],
         )
 
@@ -107,7 +100,6 @@ class BaseExternalMaterializations:
             "write_codec_options": "view",
             "config_write_partition_by_id": "view",
             "config_write_partition_by_id_name": "view",
-            "config_write_per_thread_output": "view",
         }
         check_relation_types(project.adapter, expected)
 
@@ -125,13 +117,12 @@ class BaseExternalMaterializations:
                 "write_codec_options",
                 "config_write_partition_by_id",
                 "config_write_partition_by_id_name",
-                "config_write_per_thread_output",
             ],
         )
 
         # check relations in catalog
         catalog = run_dbt(["docs", "generate"])
-        assert len(catalog.nodes) == 7
+        assert len(catalog.nodes) == 6
         assert len(catalog.sources) == 1
 
 


### PR DESCRIPTION
Reverts duckdb/dbt-duckdb#717 ; thinking that this wasn't an actual issue and the old way was simpler