### PR TITLE
Unblock mypy upgrades; isolate linter from test installs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      # mypy 1.20+ requires pathspec>=1.0, but dbt-common pins pathspec<0.13.
+      # Re-enable once dbt-common loosens its pathspec range.
+      - dependency-name: "mypy"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,8 +55,8 @@ jobs:
       - name: Install python dependencies
         run: |
           pip install pre-commit
-          pip install mypy==1.3.0
           pip install -r dev-requirements.txt
+          pip install mypy==1.19.1
           pip --version
           pre-commit --version
           mypy --version

--- a/dbt/adapters/duckdb/connections.py
+++ b/dbt/adapters/duckdb/connections.py
@@ -7,6 +7,7 @@ from typing import Set
 from typing import Tuple
 from typing import TYPE_CHECKING
 
+import dbt.adapters.exceptions
 import dbt.exceptions
 from . import environments
 from dbt.adapters.contracts.connection import AdapterRequiredConfig

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -15,7 +15,6 @@ freezegun==1.5.5
 fsspec
 gspread
 ipdb
-mypy==1.18.2
 openpyxl
 pip-tools
 pre-commit


### PR DESCRIPTION
## Summary

Dependabot's mypy bumps have been failing for a while. Two distinct problems are stacked:

1. **mypy 1.20+ is hard-blocked by an upstream conflict.** mypy 1.20 added `pathspec>=1.0.0` as a runtime dep, but `dbt-common` (transitive via `dbt-tests-adapter`) pins `pathspec<0.13`. No version of pathspec satisfies both. Because `mypy==X` lived in `dev-requirements.txt`, this conflict cascaded into every CI job (unit, functional, filebased, fsspec, plugins, buenavista) — each one couldn't even resolve dependencies, which is why #729 looked catastrophic instead of just "the linter is sad."
2. **mypy 1.19.x trips on one new false-positive.** 1.19+ got pickier about implicit namespace re-exports and flagged `dbt.adapters.exceptions.FailedToConnectError` in `connections.py:60`, where only `dbt.exceptions` was explicitly imported.

This PR:

- Adds `import dbt.adapters.exceptions` in `dbt/adapters/duckdb/connections.py` so 1.19+ is happy.
- Removes `mypy` from `dev-requirements.txt`. mypy is only needed by the `code-quality` job and the pre-commit hook, not by the test jobs that install `dev-requirements.txt`. Now a mypy version conflict can only break the linter, not all of CI.
- Pins `mypy==1.19.1` directly in the `code-quality` CI step (replaces the vestigial `pip install mypy==1.3.0` line that was being clobbered by `dev-requirements.txt` anyway). 1.19.1 already matches the `rev:` declared in `.pre-commit-config.yaml`.
- Tells dependabot to ignore mypy bumps until `dbt-common` loosens its `pathspec<0.13` pin upstream.

## Test plan

- [x] `mypy --show-error-codes --ignore-missing-imports dbt/adapters/` passes locally with mypy 1.18.2 (previous pin) and 1.19.1 (new pin).
- [x] `pre-commit run --files <changed files>` passes.
- [ ] CI green on this PR (code-quality + all test jobs install cleanly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)