### PR TITLE
Serialize MotherDuck functional runs to fix concurrency-driven flakes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -223,6 +223,14 @@ jobs:
     needs: [check-md-token]
     if: needs.check-md-token.outputs.exists == 'true'
 
+    # Tests share a single MotherDuck account/database (`md:test`), so concurrent
+    # runs across PRs/commits collide on catalog metadata and produce flaky
+    # failures. Serialize MotherDuck runs globally; queue rather than cancel so
+    # in-flight master runs aren't lost.
+    concurrency:
+      group: motherduck-functional-tests
+      cancel-in-progress: false
+
     runs-on: ubuntu-latest
 
     strategy:


### PR DESCRIPTION
## Summary

The MotherDuck functional job authenticates with a single shared MotherDuck account and runs against a single shared database (`md:test`). When multiple workflow runs are in flight at once — e.g., several dependabot PRs merging within a few minutes of each other, or a PR run overlapping a master run — they collide on catalog metadata and produce flaky, non-deterministic failures.

We saw this on 2026-04-27 when three dependabot PRs (#726, #727, #728) all auto-merged within a 3-minute window. Each of the three resulting master runs failed on a *different* test, with race-condition-shaped errors:

- `test_simple_snapshot.py::test_updates_are_captured_by_snapshot` → `Parser Error: syntax error at or near ")"` from an empty `INSERT INTO ... ()` (column readback returned nothing for a freshly-created staging table)
- `test_basic.py::TestSnapshotCheckColsDuckDB::test_snapshot_check_cols` → same empty-column-readback Parser Error
- `test_macros.py::TestMacrosGenerateDatabaseName::test_dbname_macro` → `Catalog "test_ducky_ducky" does not exist!` immediately after `CREATE DATABASE IF NOT EXISTS test_ducky_ducky` returned success

The `test_ducky_ducky` failure was the smoking gun — that database name is **hardcoded** across all four `TestMacrosGenerateDatabaseName*` classes, so concurrent CI runs CREATE/DROP it from underneath each other directly.

This adds a global `motherduck-functional-tests` concurrency group with `cancel-in-progress: false`, so MotherDuck jobs queue serially across all commits/PRs rather than running concurrently. Other jobs (local DuckDB, Buena Vista, fsspec, plugins) keep the existing per-SHA group since they don't share remote state.

## Test plan
- [x] CI passes (verified on this PR — clean run, no flakes)
- [ ] After merge, observe that overlapping pushes/PRs queue on the MotherDuck job rather than running concurrently (visible in the Actions UI as `queued` then `in_progress`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)