### PR TITLE
fix(motherduck): support motherduck_token in settings for direct profiles

### DIFF
--- a/dbt/adapters/duckdb/plugins/motherduck.py
+++ b/dbt/adapters/duckdb/plugins/motherduck.py
@@ -83,7 +83,14 @@ class Plugin(BasePlugin):
             user_agent = f"{user_agent} {custom_user_agent}"
         config[CUSTOM_USER_AGENT] = user_agent
 
-        # If a user specified MotherDuck config options via the plugin config,
-        # pass it to the config kwarg in duckdb.connect.
+        # Pass MotherDuck config options (from plugin config or settings) to
+        # the duckdb.connect config kwarg, and remove any MD keys from
+        # creds.settings so initialize_cursor doesn't re-apply them via SET
+        # post-init (which the MotherDuck extension rejects as init-only).
         if not creds.is_motherduck_attach:
-            config.update(self.get_md_config_settings(self._config))
+            merged = {**(self._config or {}), **settings}
+            md_settings = self.get_md_config_settings(merged)
+            config.update(md_settings)
+            if creds.settings is not None:
+                for key in md_settings:
+                    creds.settings.pop(key, None)

--- a/tests/functional/plugins/motherduck/test_motherduck.py
+++ b/tests/functional/plugins/motherduck/test_motherduck.py
@@ -123,6 +123,25 @@ class TestMDPlugin:
         assert res == (70,)
 
 
+@pytest.mark.skip_profile("buenavista", "file", "memory")
+class TestMDPluginWithSettings(TestMDPlugin):
+    @pytest.fixture(scope="class")
+    def profiles_config_update(self, dbt_profile_target, test_database_name):
+        md_setting = {"motherduck_token": dbt_profile_target.get("token")}
+        return {
+            "test": {
+                "outputs": {
+                    "dev": {
+                        "type": "duckdb",
+                        "path": f"md:{test_database_name}",
+                        "settings": md_setting,
+                    }
+                },
+                "target": "dev",
+            }
+        }
+
+
 @pytest.fixture
 def mock_plugin_config():
     return {"token": "quack"}


### PR DESCRIPTION
Fixes #733.

### What

For *direct* MotherDuck profiles (`path: "md:my_db"`), `motherduck_token` in `creds.settings` was neither consumed at connect time nor popped from settings, so `initialize_cursor` would later re-issue `SET motherduck_token = '...'` on the already-open connection — which the MotherDuck extension rejects as init-only:

```
Runtime Error
  setting 'motherduck_token' can only be set during initialization
```

The `attach` branch already handled this correctly in `configure_connection` (set + pop). This PR mirrors that behavior in `update_connection_config` for the direct branch: merge MD keys from `creds.settings` into the connect config and pop them out of `creds.settings` so they aren't re-applied via `SET` post-init.

### Test

Adds `TestMDPluginWithSettings` to `tests/functional/plugins/motherduck/test_motherduck.py` as a direct-mode counterpart to `TestMDPluginAttachWithSettings`. It subclasses `TestMDPlugin` to reuse all model and assertion coverage with the settings-based profile shape.

The mocked `test_motherduck_user_agent` continues to pass (verified locally).

### Other supported forms — unchanged

- `path: "md:my_db?motherduck_token=..."` (worked before, still works)
- `plugins: [{ module: motherduck, config: { token: ... } }]` (worked before, still works)
