### PR TITLE
Allowing function expressions in partition_by

### DIFF
--- a/tests/unit/test_partition_render.py
+++ b/tests/unit/test_partition_render.py
@@ -1,0 +1,45 @@
+import pytest
+from dbt_common.exceptions import DbtRuntimeError
+
+from dbt.adapters.duckdb.impl import _render_partition_part
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("col1", '"col1"'),
+        ("time field", '"time field"'),
+        ('with"quote', '"with""quote"'),
+        ("day(ts)", "day(ts)"),
+        ('day("ts")', 'day("ts")'),
+        ('day("time field")', 'day("time field")'),
+        ("bucket(16, user_id)", "bucket(16, user_id)"),
+        ('bucket(16, "user_id")', 'bucket(16, "user_id")'),
+        ("  day(ts)  ", "day(ts)"),
+        ("Day(TS)", "Day(TS)"),
+        ("quarter(ts)", "quarter(ts)"),
+    ],
+)
+def test_render_partition_part_ok(raw, expected):
+    assert _render_partition_part(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "",
+        "   ",
+        "day(ts",
+        "day(ts))",
+        "day(ts); drop table x; --",
+        "day(ts) -- comment",
+        "day(ts; drop table x;)",
+        "day(ts) drop table x",
+        "1day(ts)",
+        "day-fn(ts)",
+        "(ts)",
+    ],
+)
+def test_render_partition_part_rejected(raw):
+    with pytest.raises(DbtRuntimeError):
+        _render_partition_part(raw)


### PR DESCRIPTION
Previously, partition_by were assumed to be columns, which would always be escaped.
However `month(ts)`, if escaped would not be interpreted by DuckDB as an expression.
This logic for escaping now checks for a parentheses pair `..(..)` after a valid function name `[A-Za-z_]*` and does not escape in that case. To compensate for the risk of not escaping there are checks on SQL injection. People can still escape themselves if they need to with `month("ts")` 