### PR TITLE
Skip expand_column_types on DuckDB to avoid slow DuckLake cold-start

### DIFF
--- a/dbt/adapters/duckdb/impl.py
+++ b/dbt/adapters/duckdb/impl.py
@@ -131,6 +131,14 @@ class DuckDBAdapter(SQLAdapter):
     def debug_query(self):
         self.execute("select 1 as id")
 
+    def expand_column_types(self, goal, current):
+        # DuckDB has no VARCHAR(N) length constraint, so DuckDBColumn.can_expand_to is
+        # always False (string_size() returns 256 for every string column). The base
+        # implementation's get_columns_in_relation lookups are pure overhead -- and can
+        # be extremely slow against attached catalogs (e.g. DuckLake on Postgres) where
+        # an unfiltered information_schema.columns scan triggers a full metastore load.
+        return
+
     @available
     def parse_index(self, raw_index: Any) -> Optional[DuckDBIndexConfig]:
         return DuckDBIndexConfig.parse(raw_index)

--- a/tests/unit/test_duckdb_adapter.py
+++ b/tests/unit/test_duckdb_adapter.py
@@ -65,6 +65,17 @@ class TestDuckDBAdapter(unittest.TestCase):
         self.adapter.connections.thread_connections[key] = mock_connection("main")
         self.assertEqual(len(list(self.adapter.cancel_open_connections())), 0)
 
+    def test_expand_column_types_is_noop(self):
+        # DuckDB has no VARCHAR(N), so the base SQLAdapter.expand_column_types is dead
+        # work -- and its unfiltered information_schema.columns lookup can be very slow
+        # against attached catalogs (e.g. DuckLake). Verify the override skips it.
+        with mock.patch.object(
+            self.adapter, "get_columns_in_relation"
+        ) as get_cols, mock.patch.object(self.adapter, "alter_column_type") as alter:
+            self.assertIsNone(self.adapter.expand_column_types(mock.MagicMock(), mock.MagicMock()))
+            get_cols.assert_not_called()
+            alter.assert_not_called()
+
 
 class TestDuckDBAdapterWithSecrets(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary

Fixes #738. Overrides `DuckDBAdapter.expand_column_types` as a no-op so that incremental materializations no longer issue two `get_columns_in_relation` lookups whose results DuckDB cannot act on.

- DuckDB has no `VARCHAR(N)` length constraint, so `DuckDBColumn.can_expand_to` is always `False` (`string_size()` returns 256 for every string column). The base `SQLAdapter.expand_column_types` therefore never reaches its `alter_column_type` branch — only the column lookups remain, and they are pure overhead.
- On an incremental model against an attached DuckLake catalog backed by a bloated Postgres metastore (~150K+ snapshots in the reporter's case), the unfiltered `system.information_schema.columns where table_name = '<dbt_tmp...>'` lookup triggers a one-time DuckLake metastore load that can take 60–90s. After the cache is hot, the same query is ~0.08s.
- Diagnosis and proposed fix by @chaegordon in the issue.

## Test plan

- [x] New unit test `test_expand_column_types_is_noop` patches `get_columns_in_relation` and `alter_column_type` on the adapter and asserts neither is called.
- [x] Full unit suite passes (95 tests).
- [x] `tests/functional/adapter/test_incremental.py` passes (26 tests) on DuckDB 1.5.2.
- [x] `pre-commit run --all-files` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)