### PR TITLE
Pin dbt-core>=1.10 in dev-requirements to unblock CI

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,6 +2,13 @@
 # git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-core&subdirectory=core
 # git+https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-tests-adapter
 
+# Pin dbt-core to a stable floor. dbt-tests-adapter 1.19.x's metadata declares
+# `dbt-core>=1.8.0a1`, which enables pre-release matching and lets pip's resolver
+# pick `dbt-core==1.8.0b1` (a 2024 beta) alongside the much newer dbt-common /
+# mashumaro it also resolves. The combination has an incompatible MRO between
+# `DataClassMessagePackMixin` and `dbtClassMixin`, so `import dbt` blows up at
+# the `Manifest` class definition. Pinning to a stable floor avoids the beta.
+dbt-core>=1.10,<2
 dbt-tests-adapter==1.19.7
 
 boto3


### PR DESCRIPTION
## Summary

The `code-quality` CI job has been failing on master since shortly after #731 — every PR since (including dependabot-only bumps that touch no Python) errors out at the `dbt --version` smoke check during install with:

\`\`\`
File ".../dbt/contracts/graph/manifest.py", line 786, in <module>
    class Manifest(MacroMethods, DataClassMessagePackMixin, dbtClassMixin):
TypeError: Cannot create a consistent method resolution
order (MRO) for bases object, DataClassMessagePackMixin, dbtClassMixin
\`\`\`

Reproduced locally on Python 3.11 with current pip: `pip install -r dev-requirements.txt` resolves `dbt-core==1.8.0b1` (a 2024 beta), `dbt-common==1.38.0`, `dbt-adapters==1.23.0`, and `mashumaro==3.17` — and the beta dbt-core's `Manifest` cannot be linearized against the much newer mashumaro `DataClassMessagePackMixin`.

The reason pip picks the beta: `dbt-tests-adapter==1.19.7`'s published metadata declares `Requires-Dist: dbt-core (>=1.8.0a1)`. Per PEP 440, a pre-release lower bound enables pre-release matching for that dependency, and pip's current resolver happily resolves to `dbt-core==1.8.0b1` rather than the latest stable.

Pinning `dbt-core>=1.10,<2` in `dev-requirements.txt` keeps the resolver on stable releases. With this pin pip resolves `dbt-core==1.11.9` and `mashumaro==3.14`, and `dbt --version` succeeds.

## Test plan

- [x] In a fresh Python 3.11 venv without the pin: `dbt --version` reproduces the CI failure (MRO error).
- [x] With the pin applied: pip resolves `dbt-core==1.11.9` + `mashumaro==3.14`, and `dbt --version` exits cleanly.
- [ ] Confirm `code-quality` CI passes on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)