### PR TITLE
Add DuckLake sorted_by alter flow and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,6 +545,33 @@ select
 from {{ ref('upstream_model') }}
 ```
 
+#### DuckLake Table Sort Order
+
+For DuckLake-backed tables (including MotherDuck-managed DuckLake), you can configure a physical sort order for `table` or `incremental` models using `sorted_by`:
+
+```sql
+{{ config(materialized='table', sorted_by=['event_time']) }}
+
+select * from {{ ref('upstream_model') }}
+```
+
+`sort_by` is accepted as an alias for `sorted_by`. The setting is only applied for DuckLake relations; on non-DuckLake targets it is ignored with a warning.
+
+DuckLake applies sorting via `ALTER TABLE ... SET SORTED BY (...)`, which means the sort order persists across compactions and is used for new writes. For first builds or full refreshes, dbt-duckdb creates an empty table, sets the sort order (and partitioning, if any), then inserts data. For incremental runs that only insert/update, no ALTER is issued. `sorted_by` can be combined with `partitioned_by`:
+
+```sql
+{{ config(
+    materialized='table',
+    partitioned_by=['event_day'],
+    sorted_by=['event_time']
+) }}
+
+select
+  *,
+  date_trunc('day', event_time) as event_day
+from {{ ref('upstream_model') }}
+```
+
 
 **Merge Strategy (DuckDB >= 1.4.0):**
 

--- a/README.md
+++ b/README.md
@@ -513,23 +513,29 @@ models:
 > [!TIP]
 > Microbatching might not always be best option from a performance perspective. Consider that DuckDB operates on row groups, not physical partitions (unless you have explicitly partitioned data in a DuckLake). While you can do batch processing in parallel, more threads with more batches in parallel does not always equal better performance as row groups might not align 1-1 with the batches. Be sure to test different amounts of threads to match your use case.
 
-#### DuckLake Table Partitioning
+#### DuckLake Partitioning and Sort Order
 
-For DuckLake-backed tables (including MotherDuck-managed DuckLake), you can configure physical partitioning for `table` or `incremental` models using `partitioned_by`:
+For DuckLake-backed tables (including MotherDuck-managed DuckLake), you can configure the physical layout of `table` or `incremental` models with two settings:
+
+- `partitioned_by` (alias: `partition_by`) — physical partition keys
+- `sorted_by` (alias: `sort_by`) — sort keys applied at write time
+
+Either can be set on its own, or both together. Both settings only apply to DuckLake relations; on non-DuckLake targets they are ignored with a warning.
 
 ```sql
-{{ config(materialized='table', partitioned_by=['year', 'month']) }}
+{{ config(
+    materialized='table',
+    partitioned_by=['event_day'],
+    sorted_by=['event_time']
+) }}
 
 select
   *,
-  year(event_time) as year,
-  month(event_time) as month
+  date_trunc('day', event_time) as event_day
 from {{ ref('upstream_model') }}
 ```
 
-`partition_by` is accepted as an alias for `partitioned_by`. This setting is only applied for DuckLake relations; on non-DuckLake targets it is ignored with a warning.
-
-DuckLake applies partitioning via `ALTER TABLE ... SET PARTITIONED BY (...)`, and partitioning only affects new data. For first builds or full refreshes, dbt-duckdb creates an empty table, sets partitioning, then inserts data so the initial load is partitioned. For incremental runs that only insert/update, no ALTER is issued. See the DuckLake docs for details: [ducklake.select](https://ducklake.select/docs/stable/duckdb/advanced_features/partitioning).
+DuckLake applies these via `ALTER TABLE ... SET PARTITIONED BY (...)` and `ALTER TABLE ... SET SORTED BY (...)`, and they only affect new data. For first builds and full refreshes, dbt-duckdb creates an empty table, sets partitioning and/or sort order, then inserts data so the initial load is laid out as configured. For incremental runs that only insert/update, no ALTER is issued. See the DuckLake docs for [partitioning](https://ducklake.select/docs/stable/duckdb/advanced_features/partitioning) and [sorted tables](https://ducklake.select/docs/stable/duckdb/advanced_features/sorted_tables).
 
 Example partitions (day, month, year, hour):
 
@@ -542,33 +548,6 @@ select
   date_trunc('month', event_time) as event_month,
   date_trunc('year', event_time) as event_year,
   date_trunc('hour', event_time) as event_hour
-from {{ ref('upstream_model') }}
-```
-
-#### DuckLake Table Sort Order
-
-For DuckLake-backed tables (including MotherDuck-managed DuckLake), you can configure a physical sort order for `table` or `incremental` models using `sorted_by`:
-
-```sql
-{{ config(materialized='table', sorted_by=['event_time']) }}
-
-select * from {{ ref('upstream_model') }}
-```
-
-`sort_by` is accepted as an alias for `sorted_by`. The setting is only applied for DuckLake relations; on non-DuckLake targets it is ignored with a warning.
-
-DuckLake applies sorting via `ALTER TABLE ... SET SORTED BY (...)`, which means the sort order persists across compactions and is used for new writes. For first builds or full refreshes, dbt-duckdb creates an empty table, sets the sort order (and partitioning, if any), then inserts data. For incremental runs that only insert/update, no ALTER is issued. `sorted_by` can be combined with `partitioned_by`:
-
-```sql
-{{ config(
-    materialized='table',
-    partitioned_by=['event_day'],
-    sorted_by=['event_time']
-) }}
-
-select
-  *,
-  date_trunc('day', event_time) as event_day
 from {{ ref('upstream_model') }}
 ```
 

--- a/dbt/include/duckdb/macros/adapters.sql
+++ b/dbt/include/duckdb/macros/adapters.sql
@@ -104,11 +104,58 @@
   alter table {{ relation }} set partitioned by ({{ partitioned_by }});
 {%- endmacro %}
 
-{% macro create_table_as(temporary, relation, compiled_code, language='sql', partitioned_by=none) -%}
-  {{ return(adapter.dispatch('create_table_as', 'dbt')(temporary, relation, compiled_code, language, partitioned_by=partitioned_by)) }}
+
+{% macro duckdb__get_sorted_by(relation, temporary) -%}
+  {%- if temporary -%}
+    {{ return(none) }}
+  {%- endif -%}
+
+  {%- set raw = config.get('sorted_by', none) -%}
+  {%- if raw is none -%}
+    {%- set raw = config.get('sort_by', none) -%}
+  {%- endif -%}
+  {%- if raw is none -%}
+    {{ return(none) }}
+  {%- endif -%}
+
+  {%- set parts = normalize_string_or_list(raw, "sorted_by/sort_by") -%}
+
+  {%- if parts | length == 0 -%}
+    {% do exceptions.raise_compiler_error("sorted_by/sort_by must contain at least one column") %}
+  {%- endif -%}
+
+  {# Apply sorting only on the final target relation, not staging/intermediate relations. #}
+  {%- if this is defined and config.get('materialized') in ['table', 'incremental']
+      and relation.identifier and this.identifier and relation.identifier != this.identifier -%}
+    {{ return(none) }}
+  {%- endif -%}
+
+  {%- if not adapter.is_ducklake(relation) -%}
+    {% do adapter.warn_once(
+      "sorted_by/sort_by is only supported for DuckLake relations; ignoring for "
+      ~ relation
+    ) %}
+    {{ return(none) }}
+  {%- endif -%}
+
+  {%- set quoted = [] -%}
+  {%- for col in parts -%}
+    {%- set escaped = col | replace('"', '""') -%}
+    {%- do quoted.append(adapter.quote(escaped)) -%}
+  {%- endfor -%}
+  {{ return(quoted | join(', ')) }}
 {%- endmacro %}
 
-{% macro duckdb__create_table_as(temporary, relation, compiled_code, language='sql', partitioned_by=none) -%}
+
+{% macro duckdb__alter_table_set_sorted_by(relation, sorted_by) -%}
+  alter table {{ relation }} set sorted by ({{ sorted_by }});
+{%- endmacro %}
+
+{% macro create_table_as(temporary, relation, compiled_code, language='sql', partitioned_by=none, sorted_by=none) -%}
+  {{ return(adapter.dispatch('create_table_as', 'dbt')(temporary, relation, compiled_code, language, partitioned_by=partitioned_by, sorted_by=sorted_by)) }}
+{%- endmacro %}
+
+{% macro duckdb__create_table_as(temporary, relation, compiled_code, language='sql', partitioned_by=none, sorted_by=none) -%}
   {%- if language == 'sql' -%}
     {% set contract_config = config.get('contract') %}
     {% if contract_config.enforced %}
@@ -126,18 +173,26 @@
     {% if partitioned_by %}
       {{ duckdb__alter_table_set_partitioned_by(relation, partitioned_by) }}
     {% endif %}
+    {% if sorted_by %}
+      {{ duckdb__alter_table_set_sorted_by(relation, sorted_by) }}
+    {% endif %}
     insert into {{ relation }} {{ get_column_names() }} (
       {{ get_select_subquery(compiled_code) }}
     );
   {% else %}
-    {% if partitioned_by %}
+    {% if partitioned_by or sorted_by %}
     as (
       select * from (
         {{ compiled_code }}
       ) as model_subq
       limit 0
     );
+    {% if partitioned_by %}
     {{ duckdb__alter_table_set_partitioned_by(relation, partitioned_by) }}
+    {% endif %}
+    {% if sorted_by %}
+    {{ duckdb__alter_table_set_sorted_by(relation, sorted_by) }}
+    {% endif %}
     insert into {{ relation }}
       select * from (
         {{ compiled_code }}
@@ -149,13 +204,13 @@
     {% endif %}
   {% endif %}
   {%- elif language == 'python' -%}
-    {{ py_write_table(temporary=temporary, relation=relation, compiled_code=compiled_code, partitioned_by=partitioned_by) }}
+    {{ py_write_table(temporary=temporary, relation=relation, compiled_code=compiled_code, partitioned_by=partitioned_by, sorted_by=sorted_by) }}
   {%- else -%}
       {% do exceptions.raise_compiler_error("duckdb__create_table_as macro didn't get supported language, it got %s" % language) %}
   {%- endif -%}
 {% endmacro %}
 
-{% macro py_write_table(temporary, relation, compiled_code, partitioned_by=none) -%}
+{% macro py_write_table(temporary, relation, compiled_code, partitioned_by=none, sorted_by=none) -%}
 {{ compiled_code }}
 
 def materialize(df, con):
@@ -170,9 +225,14 @@ def materialize(df, con):
             import pyarrow.dataset
     tmp_name = '__dbt_python_model_df_' + '{{ relation.identifier }}'
     con.register(tmp_name, df)
-    {% if partitioned_by %}
+    {% if partitioned_by or sorted_by %}
     con.execute('create table {{ relation }} as select * from ' + tmp_name + ' limit 0')
+    {% if partitioned_by %}
     con.execute('alter table {{ relation }} set partitioned by ({{ partitioned_by }})')
+    {% endif %}
+    {% if sorted_by %}
+    con.execute('alter table {{ relation }} set sorted by ({{ sorted_by }})')
+    {% endif %}
     con.execute('insert into {{ relation }} select * from ' + tmp_name)
     {% else %}
     con.execute('create table {{ relation }} as select * from ' + tmp_name)

--- a/dbt/include/duckdb/macros/materializations/incremental.sql
+++ b/dbt/include/duckdb/macros/materializations/incremental.sql
@@ -17,10 +17,12 @@
   {%- set full_refresh_mode = (should_full_refresh()  or existing_relation.is_view) -%}
   {%- set on_schema_change = incremental_validate_on_schema_change(config.get('on_schema_change'), default='ignore') -%}
   {%- set partitioned_by = none -%}
+  {%- set sorted_by = none -%}
   {%- if existing_relation is none or full_refresh_mode -%}
     {%- set partitioned_by = duckdb__get_partitioned_by(target_relation, false) -%}
+    {%- set sorted_by = duckdb__get_sorted_by(target_relation, false) -%}
   {%- endif -%}
-  {%- set skip_auto_begin = partitioned_by and adapter.is_ducklake(target_relation) -%}
+  {%- set skip_auto_begin = (partitioned_by or sorted_by) and adapter.is_ducklake(target_relation) -%}
 
   -- the temp_ and backup_ relations should not already exist in the database; get_relation
   -- will return None in that case. Otherwise, we get a relation that we can drop
@@ -56,18 +58,18 @@
   {{ run_hooks(pre_hooks, inside_transaction=True) }}
 
   {% if existing_relation is none %}
-    {% set build_sql = create_table_as(False, target_relation, compiled_code, language, partitioned_by=partitioned_by) %}
+    {% set build_sql = create_table_as(False, target_relation, compiled_code, language, partitioned_by=partitioned_by, sorted_by=sorted_by) %}
   {% elif full_refresh_mode %}
-    {% set build_sql = create_table_as(False, intermediate_relation, compiled_code, language, partitioned_by=partitioned_by) %}
+    {% set build_sql = create_table_as(False, intermediate_relation, compiled_code, language, partitioned_by=partitioned_by, sorted_by=sorted_by) %}
     {% set need_swap = true %}
   {% else %}
     {% if language == 'python' %}
-      {% set build_python = create_table_as(temporary, temp_relation, compiled_code, language, partitioned_by=none) %}
+      {% set build_python = create_table_as(temporary, temp_relation, compiled_code, language, partitioned_by=none, sorted_by=none) %}
       {% call statement("pre", language=language) %}
         {{- build_python }}
       {% endcall %}
     {% else %} {# SQL #}
-      {% do run_query(create_table_as(temporary, temp_relation, compiled_code, language, partitioned_by=none)) %}
+      {% do run_query(create_table_as(temporary, temp_relation, compiled_code, language, partitioned_by=none, sorted_by=none)) %}
     {% endif %}
     {% do adapter.expand_target_column_types(
              from_relation=temp_relation,

--- a/dbt/include/duckdb/macros/materializations/table.sql
+++ b/dbt/include/duckdb/macros/materializations/table.sql
@@ -29,11 +29,12 @@
   -- `BEGIN` happens here:
   {{ run_hooks(pre_hooks, inside_transaction=True) }}
   {%- set partitioned_by = duckdb__get_partitioned_by(target_relation, false) -%}
-  {%- set skip_auto_begin = partitioned_by and adapter.is_ducklake(target_relation) -%}
+  {%- set sorted_by = duckdb__get_sorted_by(target_relation, false) -%}
+  {%- set skip_auto_begin = (partitioned_by or sorted_by) and adapter.is_ducklake(target_relation) -%}
 
   -- build model
   {% call statement('main', language=language, auto_begin=not skip_auto_begin) -%}
-    {{- create_table_as(False, intermediate_relation, compiled_code, language, partitioned_by=partitioned_by) }}
+    {{- create_table_as(False, intermediate_relation, compiled_code, language, partitioned_by=partitioned_by, sorted_by=sorted_by) }}
   {%- endcall %}
 
   -- cleanup

--- a/tests/functional/adapter/test_ducklake_sorted_by.py
+++ b/tests/functional/adapter/test_ducklake_sorted_by.py
@@ -1,0 +1,225 @@
+import re
+from pathlib import Path
+
+import pytest
+from dbt.tests.util import run_dbt
+
+
+# NOTE: This module intentionally includes "compile-only" tests that call low-level adapter
+# macros (e.g. `duckdb__create_table_as` / `py_write_table`) via small helper macros.
+#
+# Rationale:
+# - The DuckLake `sorted_by` implementation is mostly Jinja logic that decides whether to
+#   emit `ALTER TABLE .. SET SORTED BY ..` and how to validate/parse user input.
+# - These tests unit-test that compilation output includes (or omits) the expected statements,
+#   without requiring DuckLake attachments or DuckLake metadata tables.
+#
+# See `tests/functional/adapter/test_ducklake_sorted_by_integration.py` for end-to-end
+# integration tests that assert sort metadata on real DuckLake tables.
+
+models__sorted_by_table = """
+{{ config(materialized='view', sorted_by='ds') }}
+
+{{ render_create_table_as() }}
+"""
+
+models__sort_by_incremental = """
+{{ config(materialized='view', sort_by=['ds', 'region']) }}
+
+{{ render_create_table_as() }}
+"""
+
+models__sorted_by_python = """
+{{ config(materialized='view', sorted_by='ds') }}
+
+{{ render_py_write_table() }}
+"""
+
+models__contract_sorted_by = """
+{{ config(materialized='view', sorted_by='ds', contract={'enforced': True}) }}
+
+{{ render_create_table_as("select 1 as ds, 'a' as value") }}
+"""
+
+models__partitioned_and_sorted = """
+{{ config(materialized='view', partitioned_by='ds', sorted_by='region') }}
+
+{{ render_create_table_as("select 1 as ds, 'a' as region") }}
+"""
+
+models__invalid_sorted_by = """
+{{ config(materialized='view', sorted_by=['ds', 1]) }}
+
+{{ render_create_table_as() }}
+"""
+
+
+schema_yml = """
+version: 2
+
+models:
+  - name: contract_sorted_by
+    columns:
+      - name: ds
+        data_type: integer
+      - name: value
+        data_type: string
+"""
+
+macros__render_create_table_as = """
+{% macro render_create_table_as(compiled_code='select 1 as ds', temporary=false, language='sql') %}
+  {%- set partitioned_by = duckdb__get_partitioned_by(this, temporary) -%}
+  {%- set sorted_by = duckdb__get_sorted_by(this, temporary) -%}
+  {{ return(duckdb__create_table_as(temporary, this, compiled_code, language, partitioned_by=partitioned_by, sorted_by=sorted_by)) }}
+{% endmacro %}
+"""
+
+macros__render_py_write_table = """
+{% macro render_py_write_table(compiled_code='def model(dbt, session):\\n    return None', temporary=false) %}
+  {%- set partitioned_by = duckdb__get_partitioned_by(this, temporary) -%}
+  {%- set sorted_by = duckdb__get_sorted_by(this, temporary) -%}
+  {{ return(py_write_table(temporary, this, compiled_code, partitioned_by=partitioned_by, sorted_by=sorted_by)) }}
+{% endmacro %}
+"""
+
+
+def read_compiled_file(project, model_name, extension):
+    compiled_root = Path(project.project_root) / "target" / "compiled"
+    matches = list(compiled_root.rglob(f"{model_name}.{extension}"))
+    assert matches, f"Compiled file not found for model '{model_name}.{extension}'"
+
+    project_name = getattr(project, "project_name", None)
+    if project_name:
+        named_matches = [path for path in matches if project_name in path.parts]
+        if named_matches:
+            matches = named_matches
+
+    assert len(matches) == 1, f"Expected one compiled file for '{model_name}', found {len(matches)}"
+    return matches[0].read_text()
+
+
+class BaseSortedByCompile:
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "name": "ducklake_sorted_by",
+            "macro-paths": ["macros"],
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "sorted_by_table.sql": models__sorted_by_table,
+            "sort_by_incremental.sql": models__sort_by_incremental,
+            "sorted_by_python.sql": models__sorted_by_python,
+            "contract_sorted_by.sql": models__contract_sorted_by,
+            "partitioned_and_sorted.sql": models__partitioned_and_sorted,
+            "schema.yml": schema_yml,
+        }
+
+    @pytest.fixture(scope="class")
+    def macros(self):
+        return {
+            "render_create_table_as.sql": macros__render_create_table_as,
+            "render_py_write_table.sql": macros__render_py_write_table,
+        }
+
+
+class TestDucklakeSortedByCompile(BaseSortedByCompile):
+    @pytest.fixture(scope="class")
+    def dbt_profile_target(self, dbt_profile_target):
+        # Avoid mutating the session-scoped fixture in-place.
+        target = dict(dbt_profile_target)
+        target["is_ducklake"] = True
+        return target
+
+    def test_sorted_by_string(self, project):
+        run_dbt(["compile"])
+        sql = read_compiled_file(project, "sorted_by_table", "sql")
+        assert re.search(r'alter\s+table.*set\s+sorted\s+by\s*\(\s*"ds"\s*\)', sql, re.IGNORECASE | re.DOTALL)
+
+    def test_sort_by_list(self, project):
+        run_dbt(["compile"])
+        sql = read_compiled_file(project, "sort_by_incremental", "sql")
+        assert re.search(
+            r'alter\s+table.*set\s+sorted\s+by\s*\(\s*"ds"\s*,\s*"region"\s*\)',
+            sql,
+            re.IGNORECASE | re.DOTALL,
+        )
+
+    def test_sorted_by_python(self, project):
+        run_dbt(["compile"])
+        python_code = read_compiled_file(project, "sorted_by_python", "sql")
+        assert re.search(
+            r'alter\s+table.*set\s+sorted\s+by\s*\(\s*"ds"\s*\)',
+            python_code,
+            re.IGNORECASE | re.DOTALL,
+        )
+
+    def test_sorted_by_contract(self, project):
+        run_dbt(["compile"])
+        sql = read_compiled_file(project, "contract_sorted_by", "sql")
+        assert re.search(r'alter\s+table.*set\s+sorted\s+by\s*\(\s*"ds"\s*\)', sql, re.IGNORECASE | re.DOTALL)
+
+    def test_partitioned_and_sorted_together(self, project):
+        run_dbt(["compile"])
+        sql = read_compiled_file(project, "partitioned_and_sorted", "sql")
+        # Both ALTERs should appear, with partitioned before sorted.
+        assert re.search(
+            r'alter\s+table.*set\s+partitioned\s+by\s*\(\s*"ds"\s*\).*'
+            r'alter\s+table.*set\s+sorted\s+by\s*\(\s*"region"\s*\)',
+            sql,
+            re.IGNORECASE | re.DOTALL,
+        )
+
+
+class TestNonDucklakeSortedByCompile(BaseSortedByCompile):
+    @pytest.fixture(scope="class")
+    def dbt_profile_target(self, dbt_profile_target):
+        # Avoid mutating the session-scoped fixture in-place.
+        target = dict(dbt_profile_target)
+        target.pop("is_ducklake", None)
+        return target
+
+    def test_sorted_by_ignored(self, project):
+        run_dbt(["compile"])
+        sql_table = read_compiled_file(project, "sorted_by_table", "sql").lower()
+        sql_incremental = read_compiled_file(project, "sort_by_incremental", "sql").lower()
+        sql_contract = read_compiled_file(project, "contract_sorted_by", "sql").lower()
+        python_code = read_compiled_file(project, "sorted_by_python", "sql").lower()
+        assert "set sorted by" not in sql_table
+        assert "set sorted by" not in sql_incremental
+        assert "set sorted by" not in sql_contract
+        assert "set sorted by" not in python_code
+
+
+class TestSortedByValidation:
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "name": "ducklake_sorted_by_validation",
+            "macro-paths": ["macros"],
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "invalid_sorted_by.sql": models__invalid_sorted_by,
+        }
+
+    @pytest.fixture(scope="class")
+    def macros(self):
+        return {
+            "render_create_table_as.sql": macros__render_create_table_as,
+        }
+
+    @pytest.fixture(scope="class")
+    def dbt_profile_target(self, dbt_profile_target):
+        # Avoid mutating the session-scoped fixture in-place.
+        target = dict(dbt_profile_target)
+        target["is_ducklake"] = True
+        return target
+
+    def test_sorted_by_list_values_must_be_strings(self, project):
+        with pytest.raises(Exception, match="sorted_by/sort_by list values must be non-empty strings"):
+            run_dbt(["compile"])

--- a/tests/functional/adapter/test_ducklake_sorted_by_integration.py
+++ b/tests/functional/adapter/test_ducklake_sorted_by_integration.py
@@ -1,0 +1,232 @@
+from pathlib import Path
+
+import pytest
+from dbt.tests.util import run_dbt
+
+
+models__table_sorted_model = """
+{{ config(materialized='table', database='ducklake_db', sorted_by='ds') }}
+
+select 1 as id, '2025-01-01' as ds, 'us' as region, 10 as amount
+union all
+select 2 as id, '2025-01-02' as ds, 'eu' as region, 20 as amount
+"""
+
+models__incremental_sorted_model = """
+{{ config(
+    materialized='incremental',
+    database='ducklake_db',
+    unique_key='id',
+    sort_by=['ds', 'region']
+) }}
+
+{% if is_incremental() %}
+select 2 as id, '2025-01-02' as ds, 'eu' as region, 22 as amount
+union all
+select 3 as id, '2025-01-03' as ds, 'ca' as region, 30 as amount
+{% else %}
+select 1 as id, '2025-01-01' as ds, 'us' as region, 10 as amount
+union all
+select 2 as id, '2025-01-02' as ds, 'eu' as region, 20 as amount
+{% endif %}
+"""
+
+models__python_sorted_model = """
+import pandas as pd
+
+
+def model(dbt, _):
+    dbt.config(materialized='table', database='ducklake_db', sorted_by='ds')
+    return pd.DataFrame(
+        {
+            "id": [1, 2],
+            "ds": ["2025-01-01", "2025-01-02"],
+            "region": ["us", "eu"],
+            "amount": [10, 20],
+        }
+    )
+"""
+
+models__partitioned_and_sorted_model = """
+{{ config(materialized='table', database='ducklake_db', partitioned_by='ds', sorted_by='region') }}
+
+select 1 as id, '2025-01-01' as ds, 'us' as region, 10 as amount
+union all
+select 2 as id, '2025-01-02' as ds, 'eu' as region, 20 as amount
+"""
+
+models__non_ducklake_sorted_table = """
+{{ config(materialized='table', sorted_by='ds') }}
+
+select 1 as ds, 'a' as value
+union all
+select 2 as ds, 'b' as value
+"""
+
+models__invalid_sorted_by = """
+{{ config(materialized='table', database='ducklake_db', sorted_by=['ds', 1]) }}
+
+select 1 as ds, 'a' as value
+"""
+
+models__empty_sorted_by_list = """
+{{ config(materialized='table', database='ducklake_db', sorted_by=[]) }}
+
+select 1 as ds, 'a' as value
+"""
+
+models__invalid_sorted_by_string = """
+{{ config(materialized='table', database='ducklake_db', sorted_by='ds); drop table x; --') }}
+
+select 1 as ds, 'a' as value
+"""
+
+
+def get_sort_columns(project, model_name, schema_name):
+    relation = project.adapter.Relation.create(
+        database="ducklake_db",
+        schema=schema_name,
+        identifier=model_name,
+    )
+    metadata_schema = "__ducklake_metadata_ducklake_db"
+    query = f"""
+        select se.expression
+        from {metadata_schema}.ducklake_sort_info si
+        join {metadata_schema}.ducklake_sort_expression se
+          on se.sort_id = si.sort_id
+         and se.table_id = si.table_id
+        join {metadata_schema}.ducklake_table t
+          on t.table_id = si.table_id
+        join {metadata_schema}.ducklake_schema s
+          on s.schema_id = t.schema_id
+        where lower(t.table_name) = lower('{relation.identifier}')
+          and lower(s.schema_name) = lower('{relation.schema}')
+          and t.end_snapshot is null
+          and s.end_snapshot is null
+          and si.end_snapshot is null
+        order by se.sort_key_index
+    """
+    return [row[0].lower() for row in project.run_sql(query, fetch="all")]
+
+
+@pytest.mark.requires_ducklake
+@pytest.mark.skip_profile("buenavista", "md")
+class BaseDucklakeSortedBy:
+    @pytest.fixture(scope="class")
+    def ducklake_attachment(self, tmp_path_factory):
+        root = Path(tmp_path_factory.mktemp("ducklake_sorted_by"))
+        metadata_path = root / "metadata.ducklake"
+        data_path = root / "data"
+        data_path.mkdir(parents=True, exist_ok=True)
+
+        return {
+            "path": f"ducklake:sqlite:{metadata_path}",
+            "alias": "ducklake_db",
+            "options": {"data_path": str(data_path)},
+        }
+
+    @pytest.fixture(scope="class")
+    def profiles_config_update(self, dbt_profile_target, ducklake_attachment):
+        target = dict(dbt_profile_target)
+        target["path"] = target.get("path", ":memory:")
+        target["attach"] = [ducklake_attachment]
+        return {
+            "test": {
+                "outputs": {"dev": target},
+                "target": "dev",
+            }
+        }
+
+
+class TestDucklakeSortedByIntegration(BaseDucklakeSortedBy):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "table_sorted_model.sql": models__table_sorted_model,
+            "incremental_sorted_model.sql": models__incremental_sorted_model,
+            "python_sorted_model.py": models__python_sorted_model,
+            "partitioned_and_sorted_model.sql": models__partitioned_and_sorted_model,
+        }
+
+    def test_table_sorted_by_sets_sort_columns(self, project):
+        result = run_dbt(["run", "--select", "table_sorted_model"], expect_pass=True)
+        schema = result.results[0].node.schema
+        assert get_sort_columns(project, "table_sorted_model", schema) == ["ds"]
+
+    def test_table_sorted_by_is_idempotent(self, project):
+        run_dbt(["run", "--select", "table_sorted_model"], expect_pass=True)
+        result = run_dbt(["run", "--select", "table_sorted_model"], expect_pass=True)
+        schema = result.results[0].node.schema
+        assert get_sort_columns(project, "table_sorted_model", schema) == ["ds"]
+
+    def test_incremental_sort_by_sets_sort_columns(self, project):
+        run_dbt(["run", "--select", "incremental_sorted_model"], expect_pass=True)
+        result = run_dbt(["run", "--select", "incremental_sorted_model"], expect_pass=True)
+        schema = result.results[0].node.schema
+        assert get_sort_columns(project, "incremental_sorted_model", schema) == ["ds", "region"]
+
+    def test_incremental_sort_by_full_refresh_sets_sort_columns(self, project):
+        result = run_dbt(
+            ["run", "--select", "incremental_sorted_model", "--full-refresh"],
+            expect_pass=True,
+        )
+        schema = result.results[0].node.schema
+        assert get_sort_columns(project, "incremental_sorted_model", schema) == ["ds", "region"]
+
+    def test_python_sorted_by_sets_sort_columns(self, project):
+        result = run_dbt(["run", "--select", "python_sorted_model"], expect_pass=True)
+        schema = result.results[0].node.schema
+        assert get_sort_columns(project, "python_sorted_model", schema) == ["ds"]
+
+    def test_partitioned_and_sorted_together(self, project):
+        result = run_dbt(["run", "--select", "partitioned_and_sorted_model"], expect_pass=True)
+        schema = result.results[0].node.schema
+        assert get_sort_columns(project, "partitioned_and_sorted_model", schema) == ["region"]
+
+
+@pytest.mark.skip_profile("buenavista")
+class TestNonDucklakeSortedBy:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "non_ducklake_sorted_table.sql": models__non_ducklake_sorted_table,
+        }
+
+    def test_sorted_by_is_ignored_for_non_ducklake(self, project):
+        run_dbt(["run", "--select", "non_ducklake_sorted_table"], expect_pass=True)
+        relation = project.adapter.Relation.create(
+            database=project.database,
+            schema=project.test_schema,
+            identifier="non_ducklake_sorted_table",
+        )
+        row_count = project.run_sql(f"select count(*) from {relation}", fetch="one")[0]
+        assert row_count == 2
+
+
+class TestSortedByValidation(BaseDucklakeSortedBy):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "invalid_sorted_by.sql": models__invalid_sorted_by,
+            "empty_sorted_by_list.sql": models__empty_sorted_by_list,
+            "invalid_sorted_by_string.sql": models__invalid_sorted_by_string,
+        }
+
+    def test_sorted_by_list_values_must_be_strings(self, project):
+        result = run_dbt(["run", "--select", "invalid_sorted_by"], expect_pass=False)
+        assert (
+            "sorted_by/sort_by list values must be non-empty strings"
+            in str(result.results[0].message)
+        )
+
+    def test_sorted_by_empty_list_is_invalid(self, project):
+        result = run_dbt(["run", "--select", "empty_sorted_by_list"], expect_pass=False)
+        assert "sorted_by/sort_by must contain at least one column" in str(
+            result.results[0].message
+        )
+
+    def test_sorted_by_invalid_string_rejected_by_duckdb(self, project):
+        """Invalid identifier is quoted and DuckDB rejects it as a nonexistent column."""
+        result = run_dbt(["run", "--select", "invalid_sorted_by_string"], expect_pass=False)
+        message = str(result.results[0].message)
+        assert "not found" in message or "does not exist" in message


### PR DESCRIPTION
## Summary
- Adds `sorted_by` (alias `sort_by`) config for DuckLake-backed `table` and `incremental` models, mirroring the `partitioned_by` flow added in #693.
- On first create / full refresh: creates an empty table, emits `ALTER TABLE ... SET SORTED BY (...)`, then inserts. Composes with `partitioned_by` (partitioned ALTER first, then sorted).
- Non-DuckLake relations: ignored with a warning, same as `partitioned_by`.
- For now, entries are quoted as identifiers (column names only — no ASC/DESC/expressions). DuckLake defaults to ASC; lifting this restriction can be a follow-up.

Closes #724.

## Test plan
- [x] Compile tests (`test_ducklake_sorted_by.py`): string, list, python, contract, partition+sort together, non-DuckLake ignored, list-of-strings validation. All 7 pass.
- [x] Integration tests (`test_ducklake_sorted_by_integration.py`) reading `ducklake_sort_info`/`ducklake_sort_expression`: table, incremental, full-refresh, python, partition+sort, non-DuckLake ignore, validation (string list, empty list, injection-shaped string). All 10 pass.
- [x] Re-ran existing `test_ducklake_partitioned_by*` (9 pass) and `test_basic` + `test_incremental` (42 pass) — no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)