### PR TITLE
Fix __dbt_backup leak on incremental --full-refresh (#660)

### DIFF
--- a/dbt/include/duckdb/macros/adapters.sql
+++ b/dbt/include/duckdb/macros/adapters.sql
@@ -336,7 +336,10 @@ def materialize(df, con):
 {%- endmacro %}
 
 {% macro drop_indexes_on_relation(relation) -%}
-  {% call statement('get_indexes_on_relation', fetch_result=True) %}
+  {#-- auto_begin=False on these reads so this macro can run safely after
+       adapter.commit() in a materialization cleanup without opening a new
+       transaction that would later get rolled back at connection release. #}
+  {% call statement('get_indexes_on_relation', fetch_result=True, auto_begin=False) %}
     SELECT index_name
     FROM duckdb_indexes()
     WHERE schema_name = '{{ relation.schema }}'
@@ -350,13 +353,4 @@ def materialize(df, con):
       DROP INDEX "{{ relation.schema }}"."{{ index_name }}"
     {% endcall %}
   {% endfor %}
-
-  {#-- Verify indexes were dropped --#}
-  {% call statement('verify_indexes_dropped', fetch_result=True) %}
-    SELECT COUNT(*) as remaining_indexes
-    FROM duckdb_indexes()
-    WHERE schema_name = '{{ relation.schema }}'
-      AND table_name = '{{ relation.identifier }}'
-  {% endcall %}
-  {% set verify_results = load_result('verify_indexes_dropped').table %}
 {%- endmacro %}

--- a/tests/functional/adapter/indexes/test_indexes.py
+++ b/tests/functional/adapter/indexes/test_indexes.py
@@ -74,6 +74,20 @@ class TestIndex:
             ]
             assert len(indexes) == len(expected)
 
+            # Regression for #660: full-refresh must clean up the __dbt_backup table.
+            backup_tables = project.run_sql(
+                f"""
+                SELECT table_name
+                FROM information_schema.tables
+                WHERE lower(table_schema) = lower('{unique_schema}')
+                  AND table_name LIKE '%__dbt_backup'
+                """,
+                fetch="all",
+            )
+            assert backup_tables == [], (
+                f"__dbt_backup tables leaked after run: {backup_tables}"
+            )
+
     def test_seed(self, project, unique_schema):
         for additional_argument in [[], [], ["--full-refresh"]]:
             results = run_dbt(["seed"] + additional_argument)


### PR DESCRIPTION
## Summary
- Closes #660 — since v1.9.5, incremental models on `--full-refresh` left `*__dbt_backup` tables behind.
- Root cause (introduced in #522): the post-commit cleanup in `incremental.sql` calls `drop_indexes_on_relation(rel)` after `adapter.commit()`. The `SELECT … FROM duckdb_indexes()` lookup used the default `auto_begin=True`, opening a fresh transaction. The subsequent `DROP TABLE … cascade` ran inside that uncommitted txn, and dbt's connection release rolled it back (hence the `Failed to rollback` line in the report). The matching path in `table.sql` is safe because its `drop_indexes_on_relation` call lives inside the main transaction.
- Fix: set `auto_begin=False` on the index-lookup SELECT so cleanup never opens a new transaction. Also drop the dead `verify_indexes_dropped` block (it loaded a count and discarded it).

## Test plan
- [x] Extended `TestIndex::test_incremental` to assert no `*__dbt_backup` tables remain after each run — fails on master, passes with this fix.
- [x] Local: `pytest tests/functional/adapter/indexes tests/functional/adapter/test_incremental.py tests/functional/adapter/test_incremental_microbatch.py tests/functional/adapter/test_basic.py` — 59 passed.
- [x] `pre-commit run --all-files` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)