### PR TITLE
add missing rollback method to DuckDBConnectionWrapper

### DIFF
--- a/dbt/adapters/duckdb/environments/local.py
+++ b/dbt/adapters/duckdb/environments/local.py
@@ -40,6 +40,9 @@ class DuckDBConnectionWrapper:
     def cursor(self):
         return self._cursor
 
+    def rollback(self):
+        return self._cursor.rollback()
+
 
 class LocalEnvironment(Environment):
     def __init__(self, credentials: credentials.DuckDBCredentials):


### PR DESCRIPTION
when a model fails and dbt invokes a rollback.. it does the following
https://github.com/dbt-labs/dbt-adapters/blob/bda38458ebe339daaa58b16503fa6bc8ff8e9820/dbt-adapters/src/dbt/adapters/base/connections.py#L324-L336

for dbt-duckdb the .handle returns a `DuckDBConnectionWrapper`, which does not have a rollback method. with the exception handling code above the rollback would always fail and be silenced... and i suspect this is why models would frequently return `TransactionContext Error: Current transaction is aborted (please ROLLBACK)` instead of the original duckdb error as reported in https://github.com/duckdb/dbt-duckdb/issues/578...