### PR TITLE
Fix Iceberg REST CTAS + rename transaction conflict

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "additionalDirectories": [
+      "/Users/dataders/Developer/dbt-adapters"
+    ]
+  }
+}

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,58 @@
+Aleksandar Milicevic <milicoa97@gmail.com>
+Alex-Monahan <alex@motherduck.com>
+Alexander VR <6877992+AlexanderVR@users.noreply.github.com>
+Alexander VR <alexvr@gmail.com>
+Amaral Vieira <8823335+amaralvieira@users.noreply.github.com>
+Andrei <andrey.bazarenko92@gmail.com>
+Arno Roos <Arno.Roos@vrt.be>
+Benoit Perigaud <8754100+b-per@users.noreply.github.com>
+Brian Gold <brian.t.gold@gmail.com>
+Claude <noreply@anthropic.com>
+Damir Vandic <info@dvic.io>
+Dave <david.whittingham@bettermile.com>
+David Roher <david.roher@gmail.com>
+David Roher <droher@users.noreply.github.com>
+Doug Beatty <doug.beatty@dbtlabs.com>
+Dumky de Wilde <14962728+dumkydewilde@users.noreply.github.com>
+Edgar Ramírez-Mondragón <edgarrm358@gmail.com>
+Elliana May <me@mause.me>
+Felippe F. Caso <felippe.felisola@gmail.com>
+Florian <florian@motherduck.com>
+Gabor Szarnyas <szarnyasg@gmail.com>
+Gabriel Montañola <gabriel@montanola.com>
+Guen Prawiroatmodjo <guen@motherduck.com>
+Guen Prawiroatmodjo <guenevere.p@gmail.com>
+Hidde Stokvis <hidde@neverhide.nl>
+Jacob Matson <matsonj@gmail.com>
+Jeremy Cohen <jeremy@dbtlabs.com>
+Jesse Cotton <JCotton1123@gmail.com>
+Jesse Cotton <jcotton1123@gmail.com>
+Josh Wills <josh.wills@gmail.com>
+Josh Wills <josh@weavegrid.com>
+Josh Wills <jwills@datologyai.com>
+Keith Thompson <keithjoethompson@gmail.com>
+Kshitij Aranke <kshitij.aranke@dbtlabs.com>
+Leonardo Horta <rigatto@uol.com.br>
+Lieven <lieven.verswyvel@dataminded.be>
+Louisa H <54686345+hrl20@users.noreply.github.com>
+Louisa Huang <louisa@motherduck.com>
+Michelle Ark <MichelleArk@users.noreply.github.com>
+Michelle Ark <michelle.ark@dbtlabs.com>
+Nathan <nathan.clerkx@gmail.com>
+Nintorac Dev <Nintorac@users.noreply.github.com>
+Olivier Agudo-Perez <perez@ai-2.mdpi.com>
+Radek Tomšej <radek.tomsej@almamedia.com>
+Radek Tomšej <radek@tomsej.cz>
+Thom van Engelenburg <t.v.engelenburg@gmail.com>
+Thomas Boles <tcboles@users.noreply.github.com>
+Thomas Daniels <daniels.thomas@pm.me>
+Thomas H <tehunter@users.noreply.github.com>
+Tobias Hoffmann <130311884+thfmn@users.noreply.github.com>
+W. Aaron Morris <waaronmorris@gmail.com>
+dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
+dwreeves <xdanielreeves@gmail.com>
+gregwdata <79663385+gregwdata@users.noreply.github.com>
+mehd-io <mehdi@mehd.io>
+mrjsj <jimmyjensen227@gmail.com>
+oagudoperez <olivier.agudo@mdpi.com>
+wideltann <tdellettwion@gmail.com>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,0 +1,882 @@
+CHANGES
+=======
+
+* Bump mypy from 1.18.1 to 1.18.2 (#637)
+* Break out create temp schema into its own transaction (#638)
+* Add Python 3.13 support in CI and metadata (#634)
+* Fix excel plugin skip\_empty\_sheets (#635)
+* Bump mypy from 1.17.1 to 1.18.1 (#633)
+* DuckLake connection instructions (#632)
+* Fix for attach test failures in nightly (#631)
+
+1.9.6
+-----
+
+* Remove extraneous log() lines for index-related operations (#630)
+
+1.9.5
+-----
+
+* bump duckdb to 1.3.2 (#629)
+* Bump actions/setup-python from 5 to 6 (#628)
+* An updated version of the code to add support for indexes to dbt-duckdb (#522)
+* do ATTACH IF NOT EXISTS for attachments (#626)
+* Support ducklake database in primary database and add is\_ducklake flag to identify motherduck managed ducklake (#625)
+* duckdb: fix dateadd interval syntax for newer DuckDB versions (#624)
+* Display traceback when Python model raises exception (#621)
+* add is\_ducklake flag + tests (#620)
+* tests: support DuckDB nightly IOException import (#618)
+* Bump dbt-tests-adapter from 1.17.0 to 1.18.0 (#613)
+* Update excel plugin to filter all null rows (#615)
+* Change logger.exception to logger.warning to fix orchestrator compatibility (#612)
+* Bump actions/checkout from 4 to 5 (#610)
+* Fix secrets map/list type handling in DuckDB SQL generation (#609)
+* Bump freezegun from 1.5.3 to 1.5.5 (#607)
+* Bump actions/download-artifact from 4 to 5 (#606)
+* Bump mypy from 1.17.0 to 1.17.1 (#604)
+* Bump dbt-tests-adapter from 1.16.0 to 1.17.0 (#602)
+* Bump mypy from 1.16.1 to 1.17.0 (#597)
+* Add struct column support with flatten functionality (#594)
+* Bump pyarrow from 18.1.0 to 21.0.0 (#598)
+* Bump freezegun from 1.5.2 to 1.5.3 (#595)
+* Update incremental.sql (#591)
+* Make the adapter.commit call inside of upstream.sql dependent on the existence of upstream\_nodes (#588)
+* Bump mypy from 1.16.0 to 1.16.1 (#582)
+* Bump sigstore/gh-action-sigstore-python from 3.0.0 to 3.0.1 (#583)
+
+1.9.4
+-----
+
+* fix write conflict when first creating dbt\_temp schema (#584)
+* bump duckdb to 1.3.1 (#585)
+* Fix error swallowing that hides DuckDB exception details (#579)
+* Fix bug where schema's database not specified (#577)
+* Assume native comment support in DuckDB catalog queries (#571)
+* Bump dbt-tests-adapter from 1.15.1 to 1.16.0 (#570)
+* Fix attachment option quoting to prevent SQL errors with path-like values (#566)
+* FIX: Fixes issue caused by external materializations with column name contains spaces (#563)
+* Bump mypy from 1.15.0 to 1.16.0 (#561)
+* Bump dbt-tests-adapter from 1.15.0 to 1.15.1 (#562)
+* Update macros for dropping schema and relations when using ducklake (#557)
+* Support using attached database aliases as primary database name
+* lint stuff
+* Add support for arbitrary key-value pairs in Attachment ATTACH options
+* Bump freezegun from 1.5.1 to 1.5.2
+* See if this is related to the mysterious doc test failures that popped up all of a sudden
+* Read .duckdbrc file on DuckDBT CLI startup
+* Add named secret parameter to attachment class
+* Bump dbt-tests-adapter from 1.11.0 to 1.15.0
+* add tests and quoting - reset to single commit
+
+1.9.3
+-----
+
+* Add info on the interactive shell for the DuckDB UI
+* bump duckdb version, patch test (#542)
+* remove duckdbt entrypoint for now
+* Fix: turn transactions back on by default for MotherDuck (#540)
+* Fix: override \`run\_hooks\` macro so we can run a post hook outside a txn without dangling \`commit;\` (#539)
+* - trailing whitespace
+* Update README.md to clarify DuckDB file path behavior and automatic database creation
+* Add support for scoped secrets/credentials by storage prefix (#530)
+* Update test\_basic.py
+* Support dbt\_valid\_to\_current for snapshots
+* Test alter table add column works without recreate
+* formatting fixes
+* rename to table\_function from parameterized\_view
+* Formatting fixes. Missed the pre-commit hook!
+* parameterized\_view custom materialization to avoid view recreation on schema change
+* Tweak this impl a bit
+* Add model completion with fzf integration
+* Add manifest tracking to duckdbt shell
+* linting etc
+* Vibe-claudeing a duckdbt CLI
+* remove print statement, use empty string instead (#517)
+
+1.9.2
+-----
+
+* Bump dbt-tests-adapter from 1.10.4 to 1.11.0 (#509)
+* Bump mypy from 1.14.1 to 1.15.0 (#508)
+* skip s3 tests if the secrets are not available (#511)
+* [Fix] External materialization to S3 does not work if table is empty (#510)
+* Update deprecated v3 -> v4 for upload-artifact and download-artifact (#507)
+* Make keep\_open: true the default setting for dbt-duckdb going forward (#502)
+* remove package build/test build steps (#498)
+* run on schedule
+* add nightly tox env that installs duckdb nightly release, add github action for nightly tests
+* Bump mypy from 1.13.0 to 1.14.1
+* add support for per\_thread\_output in external materialization
+* Fix out of date README comment about version support for dbt-core and duckdb (#487)
+* Drop 3.8 support, add 3.12 (#490)
+* download-artifact should also be bumped to v4 (#489)
+* bump github actions versions (#486)
+* use session scoped fixture
+* use tmp\_path instead of tmp\_dir\_factory.getbasetemp
+
+1.9.1
+-----
+
+* Add unique UUID to temp table name (#482)
+* fix(postgres-plugin #478): Correct attribute access, plugin initialization, and test assertions; gitignore for a wsl development workflow
+* autodiscovery for pytest unit tests
+* adding default open dir to the dev container
+* Bump dbt-tests-adapter from 1.10.3 to 1.10.4
+* Bump mypy from 1.11.2 to 1.13.0
+* Update README.md to reflect postgres attachments
+* Bump dbt-tests-adapter from 1.10.2 to 1.10.3
+* Add safety check for node in graph
+* Remove mention of outdated MotherDuck constraints
+* fix
+* Move the secret creation to a connection-level operation instead of a cursor-level (aka per-thread) operation
+* resolved indentation & format issues
+* infer type from location, default to parquet if not set
+* added glue client fix (local variable 'client' referenced before assignment)
+* removed empty line
+* auto\_detect=true default values for json and csv
+* set default values for csv/json/parquet read options
+* adding transaction support in md
+* removed double inport
+* fixed ruff issues
+* added parquet & json read options + added struct field support for glue
+* Update to Buena Vista 0.5.0
+* Move this message to a one-time warning function
+* Just send this to the dbt.log instead of to stdout to make it less noisy
+* Include the relation in question in the log message for the grant no-op
+* Linting fixes for PR #456
+* Make grant configs a no-op for DuckDB
+* Support HTTP secret extra\_http\_headers
+
+1.9.0
+-----
+
+* Bump dbt-tests-adapter from 1.9.2 to 1.10.2 (#454)
+* (fix) generate\_database\_name macro should be case insensitive (#453)
+* Add support for configuring community/nightly extensions in the profile directly
+* check if config has model attr (#451)
+* Test with dbt-core prereleases
+
+1.8.4
+-----
+
+* Put the dev-requirements back the way they were
+* Try out this hack
+* Update the versions of Python we run tests against from 3.9 through 3.12
+* (fix): MotherDuck config should set SaaS mode at the end (#446)
+* (fix) Add support for attaching a MotherDuck database with token in settings or config (#444)
+* A version-independent fix for the datediff week handling in duckdb
+* Add explicit register/unregister operations for python models
+* remove deprecated functions
+* consistently use kwargs
+* support preleases
+* formatting
+* not never, never
+* add type hint for secrets
+* formatting
+* pass credentials to Glue plugin constructor, secrets should always have a value
+* Disable Python models on MotherDuck when SaaS mode is on (#435)
+* Bump mypy from 1.11.1 to 1.11.2
+* author-email -> author\_email (#428)
+
+1.8.3
+-----
+
+* (chore) Use pbr for packaging for automated versioning with git tag, move to setup.cfg (#427)
+* Bump mypy from 1.11.0 to 1.11.1
+* fix(secrets): value should be enclosed in quotes (#421)
+
+1.8.2
+-----
+
+* Prep for 1.8.2 release (#418)
+* Bump DuckDB version to 1.0.0
+* Bump mypy from 1.10.1 to 1.11.0
+* formatting and typing
+* dataclasses don't like extra kwargs so let's move List[Secret] to a private attribute
+* Let duckdb handle the validation logic
+* add scope to test
+* Bump dbt-tests-adapter from 1.9.1 to 1.9.2
+* Fixes #412 by not requiring aliases for limit 0 clauses in dbt-duckdb
+* Bump mypy from 1.10.0 to 1.10.1
+* type fixes
+* Formatting and types
+* Bump dbt-tests-adapter from 1.8.0 to 1.9.1
+* pass credentials to plugin, get creds in glue plugin
+* formatting, mypy fix
+* Deprecate using settings for secrets, bump duckdb version requirement to 0.10.0
+* clean up code, add docstrings
+* add HF secret
+* add scope
+* fix typo
+* add Azure secret
+* make test more useful
+* fix typo in test
+* Update readme
+* prepared statements doesn't work for secrets
+* mypy fixes
+* pre-commit
+* remove add\_secret method
+* create or replace secret if a name is specified
+* run create secret on cursor init
+* convert secrets dict to secrets in post constructor
+* rename test\_connections to test\_credentials
+* add .env to gitignore
+* put secrets stuff in own module
+* need this for Python 3.12
+* Add add\_secret method to creds
+* Bump duckdb from 0.10.2 to 1.0.0
+
+1.8.1
+-----
+
+* Prep for 1.8.1
+* Fix version constraints
+* Skip duckdb v0.10.3
+* Bump freezegun from 1.5.0 to 1.5.1
+
+1.8.0
+-----
+
+* Adjust this since we won't need to change it going forward anymore
+* Prep for 1.8.0
+
+1.7.5
+-----
+
+* Prep for the 1.7.5 release
+* Update the README with examples of using either meta or config for setting up external sources
+* Bump dbt-tests-adapter from 1.7.11 to 1.7.14
+* Use duckdb 0.10.2
+* Use different MD token
+* Bump freezegun from 1.4.0 to 1.5.0
+* Bump mypy from 1.9.0 to 1.10.0
+* Setup python dep as well
+* Update the devcontainer/pre-commit to use Python 3.11
+* May just have to skip it in memory cause I think maybe it works in file-mode
+* Try whistling this
+* Make this test not flaky
+* precommit etc
+* Skip BV for TestUnitTestingTypesDuckDB
+* address comments
+* query cancellation
+* Added profile\_name to boto3 Session
+
+1.7.4
+-----
+
+* Prepare a 1.7.4 release
+* Skip this test in BV for the moment
+* Readd dbt-core to setup.py for install back-compat
+* Check if token exists before running MotherDuck CI/CD job
+* run tests on master not main
+* Add pre-model hook for cleaning up remote temporary table (MotherDuck)
+* Readd dbt-tests-adapter
+* Revert dev-requirements
+* Bump dbt-tests-adapter from 1.7.10 to 1.7.11
+* Skip persist\_docs for MD
+* Fix unit tests
+* Fix semver comparison logic
+* run ruff
+* lazy load agate
+* fix newline
+* Add support for persist\_docs-related functionality now that comments are fully supported in DuckDB 0.10.1
+* formatting + initial mypy fixes
+* Bump dbt-tests-adapter from 1.7.9 to 1.7.10
+* use RelationConfig attributes in create\_from\_source
+* Bump sigstore/gh-action-sigstore-python from 1.2.3 to 2.1.1
+* Bump actions/setup-python from 4 to 5
+* Bump mypy from 1.8.0 to 1.9.0
+
+1.7.3
+-----
+
+* fix that too
+* Fix module field reference on PluginConfig for MD
+* Prepare a 1.7.3 release
+* Update release.yml
+* use --generate-notes in gh release
+* only run release pipeline on semver tag pushes
+* reorder imports
+* fix: custom\_user\_agent does not work if motherduck plugin is not specified, add dbt-duckdb version
+* add release pipeline
+* Bump dbt-tests-adapter from 1.7.8 to 1.7.9
+* implement DuckDbRelation.create\_from, fix TestExternalSources::test\_external\_sources
+* bump dbt-common and dbt-adapters to 1.0.0b1
+* mypy fix
+* mypy fix
+* mypy fix
+* pop custom\_user\_agent from settings, add unit test
+* Add test for date\_spine use case
+* Update dateadd to work with new datediff
+
+1.7.2
+-----
+
+* README updates
+* Prep for 1.7.2 release
+* Fixing this b/c it bothers me
+* Bonus: functional tests for dbt unit testing
+* Fix unit tests
+* Try different install reqs
+* Migrate to dbt-common + dbt-adapters
+* Bump dbt-tests-adapter from 1.7.7 to 1.7.8
+* Clarify docstring
+* move token\_from\_config to plugin
+* missed one
+* use Dict instead of dict to be backward compatible with older Python versions
+* Move config update logic into MotherDuck Plugin
+* Rename motherduck\_token property to token\_from\_config and add docstr
+* add md to extras\_require and constrain duckdb version, update in tox.ini
+* address mypy issues
+* fix: both lower and upper caps not defined
+* address mypy error
+* MD also supports lowercase for config options
+* formatting
+* set upper limit for duckdb version
+* pass plugin config token via duckdb connect config
+* Switch to using DuckDB's built-in date\_diff function for the datediff utils macro
+* fixed p\_column error
+* partition\_column type info & parse function
+* reorder lines in UT
+* remove redundant test, use creds.is\_motherduck to determine if user agent should have been passed or not
+* add trailign whitespace
+* Add test that shows no user agent when connecting to non-md path
+* remove redundant fixture, use \_\_version\_\_ instead of hardcoded
+* Add custom\_user\_agent to config, add UT
+* Bump dbt-tests-adapter from 1.7.6 to 1.7.7
+* remove superfluous need\_drop\_temp variable and add temp\_relation to to\_drop within if-statement
+* Update dbt/adapters/duckdb/impl.py
+* Add plugin test to MotherDuck tox environment
+* update docstring
+* add \_temp\_schema\_name attribute to adapter
+* address mypy issues
+* Add test for temp schema name config
+* formatting
+* make temp schema name configurable, fix bugs for local in-memory tests
+* Reverse change to tox.ini for CI
+* use credentials.is\_motherduck in LocalEnvironment
+* Set md profile path back to md:test, make database\_name fixture
+* use adapter.is\_motherduck
+* Don't drop temp schema after test ends
+* Don't use MD\_CONNECT, instead use SET motherduck\_token
+* Create remote temporary tables in a separate schema dbt\_temp
+* create temp schema if needed
+* add more cleanup to UT, add schema temp to target database for temp table workaround
+* add some helpful inline comments
+* clean up temp tables for incrementals, add db creation and cleanup for md tests
+* use py311 for md tox env
+* clarify docstring
+* clarify docstsring
+* consolidate MotherDuck plugin tests
+* Add UT to test incremental model on MotherDuck
+* add is\_motherduck property to credentials
+* added support to dynamically registering/adding partitions (not just specifying the partition columns in the glue table but for each external s3 write,we want to register those partitions and their s3 locations in glue too)
+* clarify inline comment
+* add workaround for temporary tables in remote databases
+* Bump dbt-tests-adapter from 1.7.5 to 1.7.6
+* passed the typekey test
+* fixed partition\_columns hint
+* Fixed parameter hint for partition\_columns
+* set s3\_parent path to original if partitioning is used
+* fixed assertion, won't add partitionkeys if no partition\_columns are present
+* removed old argument
+* added partition support for Glue
+* Bump dbt-tests-adapter from 1.7.4 to 1.7.5
+* Add note about incremental materialization strategies
+
+1.7.1
+-----
+
+* Bump mypy from 1.7.1 to 1.8.0
+* Bump freezegun from 1.3.1 to 1.4.0
+* Testing other types of exceptions being retryable
+* Revert "Provide support for Postgres-specific ATTACH options"
+* Test updates for the new retry settings/config
+* Make the query tests pass again
+* generalize this for connect retries as well as query retries
+* Generalize this a bit while we figure out what exactly is getting thrown
+* Add support for retrying certain types of exceptions we see when running models in dbt-duckdb
+* Bump dbt-tests-adapter from 1.7.3 to 1.7.4
+* Provide support for Postgres-specific ATTACH options
+* point to duckdb supported version doc for motherduck
+* bump version supported by MotherDuck
+* Bump actions/setup-python from 4 to 5
+* Bump freezegun from 1.3.0 to 1.3.1
+* That turned out to be more work than I thought
+* why are you like this
+* Fixes #304
+* Adjust line lengths everywhere
+* Move from black/flake to ruff and fix the stuff ruff found
+* Bump dbt-tests-adapter from 1.7.2 to 1.7.3
+* Bump freezegun from 1.2.2 to 1.3.0
+* sqlite write issue fixed
+* tests reproduce the issue
+* Bump mypy from 1.7.0 to 1.7.1
+* Bump dbt-tests-adapter from 1.7.1 to 1.7.2
+* Bump dbt-tests-adapter from 1.7.0 to 1.7.1
+* Bump black from 23.10.1 to 23.11.0
+* Bump mypy from 1.6.1 to 1.7.0
+* Update sqlalchemy.py
+* Update sqlalchemy.py
+* Add support for providing additional kwargs for sqlalchemy connection
+* Update README.md
+
+1.7.0
+-----
+
+* Update deps for the real dbt-core 1.7.0 stuff
+* Remove unused hologram-dependent unit tests
+* Working test adapter version
+* Add in all of the seed delimiter tests
+* Support delimiter options inside of the dbt-duckdb fast seed loader
+* Mark these tests as skipped for the moment
+* Placeholders for the not-yet-working date spine tests
+* Version bumps for 1.7.0
+* Bump black from 23.10.0 to 23.10.1
+
+1.6.2
+-----
+
+* Prep and cut a 1.6.2 release
+* update delta readme
+* format fixes
+* adapt readme; add default materialization config
+* Bump mypy from 1.6.0 to 1.6.1
+* Bump black from 23.9.1 to 23.10.0
+* Nit
+* Bump MotherDuck's version requirement
+* See if that makes the precommit checks happier
+* With linting enabled and fixes for it
+* refactor df registration for more general approach
+* Update README with latest target DuckDB version
+* Update Excel plugin with output support
+* Bump dbt-tests-adapter from 1.6.5 to 1.6.6
+* Bump mypy from 1.5.1 to 1.6.0
+* use tempfile
+* change pyarrow\_table to pyarrow\_dataset; use tempfile
+* re-enable ability to return a DuckDbPyRelation that holds a reference to temp tables in a dbt python model
+
+1.6.1
+-----
+
+* Prep for 1.6.1 release
+* fix readme
+* update readme
+* add delta\_table3\_expected in test
+* addapt test; add create schema; fix storage
+* delete redudant configure call
+* delete test delta
+* refactor registered df; delete launch
+* add df registration
+* try to register df to localsession
+* simplify test\_delta
+* make duplicate connection example simple
+* add notebook with delta+conn testing
+* add simple test showcase
+* add time travel; remote storage (should test)
+* add delta read plugin
+* Fix cursor isolation on Python model
+* Add creds as arg
+* Initialize new cursor
+* Add batch example
+* Add separate cursor for batch reads/writes
+* Bump dbt-tests-adapter from 1.6.4 to 1.6.5
+* Bump dbt-tests-adapter from 1.6.3 to 1.6.4
+* put the threads settings in there too
+* Add a sample\_profiles.yml file for dbt-duckdb to make an initial 'dbt init' even more seamless
+* pydoc'ing some things and relaxing the Pandas dev requirement now that DuckDB 0.9.0 is out the door
+* Bump dbt-tests-adapter from 1.6.2 to 1.6.3
+* Allow access to the RuntimeConfigObject from the TargetConfig used by the store method of plugins
+* Refactor render\_write\_options for direct option rendering
+* Fix typos and formatting issues in dbt-duckdb README documentation
+* Add a more helpful error message in the case that the options argument to an external materialization is not a dictionary
+* Add a maxfail arg to the MD pytest runs so they fail quickly
+* Re-enable all of the core tests for MD
+* need to adjust the workflow too
+* Require the MOTHERDUCK\_TOKEN to be present in the environment; cut back on BV test runs to make things go faster
+* See if I can isolate whatever issue is springing up with the MotherDuck integration tests
+* Bump dbt-tests-adapter from 1.6.1 to 1.6.2
+* Bump black from 23.7.0 to 23.9.1
+* Pin pandas depenedency to 2.0.0 to get around dtypes error in integration tests
+* Bump actions/checkout from 3 to 4
+* Bump dbt-tests-adapter from 1.6.0 to 1.6.1
+* Bump mypy from 1.5.0 to 1.5.1
+* Update README.md
+* Bump mypy from 1.4.1 to 1.5.0
+* Add option to fetch Gsheet data using range
+* fix path
+* Update README.md
+* Update excel.py
+* fix: change quoting character
+* feat: add s3 support to excel plugin through env
+* separate out motherduck plugin test from the others, and skip when using a non-motherduck profile
+* fix skip\_by\_profile\_type fixture to apply to class-level tests and fixtures, especially since is only used at the class level
+* add source tags to SourceConfig
+
+1.6.0
+-----
+
+* Update README for 1.6.0
+* Update for mypy fixes
+* Simplify and fix bug in the split\_part utils macro
+* Prep for dbt 1.6.0 update
+* Add an option to the profile for specifying additional entries for sys.path and revamp how we lookup builtin plugin modules
+* Make fast seed loading the default
+* try whistling this
+* Fix that bit too
+* See if this makes the MD integration test stuff work properly
+* Bump dbt-tests-adapter from 1.5.2 to 1.5.4
+* Bump black from 23.3.0 to 23.7.0
+* fix: remove parenthesis from md\_connect call
+* Require duckdb >= 0.7.0 for dbt-duckdb going forward and remove some dead code
+* Add a keep\_open option to the profile
+* Some config args to make the updated plugins test run on GH
+* Add in plugins for the motherduck and postgres extensions so we can do a little bit of profile-safe initialization work
+* Updates to support the revamped dbt debug command
+* Simplify some setup stuff now that Python 3.7 is EOL'd
+* Make it nicer to run the functional adapter tests on OS X
+* picky picky
+* Check and reset the environment for a DuckDB connection if the credentials have changed
+* Disable these tests on MD and add a note to the README
+* Try to figure out what is going on with the MD integration tests
+* Bump dbt-tests-adapter from 1.5.1 to 1.5.2
+* Bump mypy from 1.3.0 to 1.4.1
+* Handle the remote case clean-er
+* Add more detailed checks to ensure consistent settings between the connection path and database name in the profile
+
+1.5.2
+-----
+
+* Document the Plugin.store functionality
+* Add in MotherDuck docs and do a version bump
+* Disable this test for now while DuckDB issue 7934 gets worked out
+* Support alternate string formatting strategies for external sources
+* ack don't need that now
+* Add an example of doing a write-side operation in the sqlalchemy plugin
+* Automatically disable transactions on motherduck paths
+* just ignore this typecheck'd bit then
+* Fix whitespace
+* Wire up MotherDuck CI tests
+* Some cleanup items
+* Version that has all tests passing with the md test profile except for the ones that can't pass b/c the functionality isn't supported
+* A more-working version
+* Keep any MD connections open in local mode, just like we do for the in-memory connections
+* Add an alias here for the update target to get around whatever is broken when running against MD
+* disable\_transactions test
+* Start working on a transaction-less mode for dbt-duckdb to see if I can get the db files to be smaller after dbt-duckdb runs
+* Prep for Python 3.7 EOL
+* add missing newline
+* Updates to support a broader class of incremental functionality
+* Simplify extension loading in dbt-duckdb
+* refrain from loading data in Relation.create\_from\_source unless we have an active environment
+* Some more tweaks to this interface
+* Bump dbt-tests-adapter from 1.5.0 to 1.5.1
+* Bump dbt-tests-adapter from 1.5.0 to 1.5.1
+* fix unit test
+* and now with a \*working\* glue test, hooray
+* A functional plugin test for the glue stuff
+* Add a write-side plugin hook and port the glue stuff over to be its first implementation
+* Step 1: Cleanup the SourceConfig class and make it more pythonic
+* Some fixes for catalog lookups in a multi-database, multi-schema world of DuckDB queries: ensure that we are always looking for the relations we need to find in as specific a way as possible (so ideally, database + schema + identifier whenever all 3 fields are available to use and supported by DuckDB)
+* Update README with details on plugin stuff
+* spec out plugin config and writing your own stuff
+* revamp the python support section
+* docstrings for the BasePlugin class
+* Add tests and the stuff I needed to add to actually make this thing work
+* Revamp the plugin structure and add in the ability to do some initialization of the DuckDB connection itself
+* put a pin in this
+* now with tests
+* Little bit more on this
+* Create a fast-loading mechanism for seed files using DuckDB's COPY command
+* Bump mypy from 1.2.0 to 1.3.0
+* For the remote.password stuff to work we need to actually pass it to psycopg2.connecct
+* Prepping the dbt-duckdb tests to pass under the next release of DuckDB
+
+1.5.1
+-----
+
+* Prep a 1.5.1 release to fix the myriad bugs in the 1.5.0 release
+* pyarrow should not be required to run dbt-duckdb python models
+* Have the local environment release the connection when it's not in use and not necessary for in-memory runs
+* Set a default value for the conn attribute in the case an exception is thrown during init
+* oh yep that also
+* more tests that need updating
+* update the attach test
+* Support profiles that are simply 'type: duckdb' by correctly configuring the in-memory database in dbt-duckdb
+* Use config info from the source.config and source.table.config entries as well in plugins and external location configuration
+
+1.5.0
+-----
+
+* yep that one is important too; I really should have a process for this
+* oh yeah that bit is important too
+* Do the 1.5.0 release
+* still kind of a thrill whenever the tests save my ass
+* fix newline
+* Handle URI-style paths correctly in dbt-duckdb
+* add in tz-aware timestamp test
+
+1.4.2
+-----
+
+* Doing a 1.4.2 release to pickup bug fixes ahead of the 1.5.0 cutover
+* simplify this back down
+* let's try whistling this
+* now with format fixes
+* Renaming/refactoring some things
+* Bump dbt-tests-adapter from 1.4.5 to 1.4.6
+* stopping here for the night; need to do most of the localenv stuff tmrw
+* fix that
+* Just trying to see where this leads me
+* First up: this is a bit nicer
+* Reorder logic, fix tests
+* Add back the test imports I foolishly removed
+* Fixup create\_table\_as logic
+* Add references alias for foreign\_key
+* Add support for model contracts in v1.5
+* Update the snapshot merge SQL to sync it up with the Postgres impl; re-enable the tests
+* Add in some of the new test functionality and restructure the directory a bit to prep for some extensions
+* Various updates so tests will work against 1.5.0
+* Version bumps
+* Enable additional iceberg config options + and add a Spark-style save mode argument for plugin-based sources
+* Add the option to materialize a plugin source as a view instead of a table
+* Add in iceberg tests and some additional functionality for scan filtering
+* Add in the sheet\_name parameter and some more test checks
+* Apparently you can't have multiple tests in a suite that both override profiles\_config\_update, or something
+* rm unused import
+* try to get some more detail on what is going wrong here since this works locally
+* really shouldn't ever let gpt3.5 write code, lesson learned
+* Add in sqlalchemy dev dep
+* this is why gpt3.5 isn't allowed to write code anymore
+* Add in a SQLAlchemy plugin
+* Fixing bugs and adding a test case (that only runs on my machine) for the gsheet plugin
+* Bump mypy from 1.1.1 to 1.2.0
+* Only install pyiceberg in the plugins test until we stop support for 3.7
+* Okay I think that's all of the basics
+* Simplify the sources test a bit
+* commit those bits too
+* WIP: source plugins
+* Conditional branching on self.remote
+* Set unique\_field in credentials.py
+* plugins WIP
+* Fix this bit up
+* only return non-empty creds to prevent code 400 when session token is empty
+* Bump black from 22.12.0 to 23.3.0
+* Wire up GH integration tests to run against a Buena Vista server
+* Ensure an event loop exists before we run a python module
+* Adding in a simple BV server for testing purposes
+* really looking forward to when gpt4 does this stuff for me
+* didn't do flake for some reason, huh
+* black etc
+* Adds a remote environment for DuckDB databases running in a Buena Vista server using the postgres protocol
+* Wire up GH Actions to always run file-based tests as well as in-memory tests
+* add format to fix glue registration bug
+* Change profile-type to 'file'
+* Inject any key-value pairs from the meta dictionary into the f-string context we use for rendering the location of an external source
+* Simplify environment and connection
+* Update .gitignore
+* Fix tests so they can run against a file db
+* Run every functional test in multithreaded mode by default
+* fix comma vs spaces causing empty test. Use the upstream config to generate the upstream options
+* pre-commit things
+* Refactor the code in the connections module into the credentials and environments modules
+
+1.4.1
+-----
+
+* More doc fixes and a version bump for the release
+* Test for the external json formatting
+* Oh yeah I think JSON works too now, yay
+* Okay have mostly got this together now
+* Some incremental progress here
+* update the historical changelog
+* Add a test that shows that pyarrow.dataset.Dataset is supported as a return type for Python models
+* Bump mypy from 1.0.1 to 1.1.1
+* Bump dbt-tests-adapter from 1.4.4 to 1.4.5
+* Bump dbt-tests-adapter from 1.4.3 to 1.4.4
+* fix: handle multithreaded writes of pyarrow models
+* fix: clear connections before tests
+* Some more targeted unit tests for the new adapter functions
+* case shouldn't matter here
+* Test some slightly different things here
+* loadbearing config change that
+* Fix mypy thingy
+* Expand the set of quoted chars here
+* fix some things the tests found
+* Refactor/generalize the external materialization's write options since there are a lot of them
+* WIP for this, add in the infra I need
+* Bump dbt-tests-adapter from 1.4.1 to 1.4.3
+* fix test dbt selection to run both models, not their empty intersection. Fix load\_upstream macro to commit the newly created views
+* Bump mypy from 1.0.0 to 1.0.1
+* ah tweaking this so as not to trigger GH rate limit issues
+* loadbearing whitespace
+* Try moving the filesystem tests into their own workflow given the extra deps
+* Add filesystems integration tests + fix up some of the other integration test fixtures
+* Update dbt/adapters/duckdb/connections.py
+* Update dbt/adapters/duckdb/connections.py
+* WIP: Add support for reading/writing with fsspec-compatible filesystems
+
+1.4.0
+-----
+
+* README updates for attaching databases
+* Create attach-specific functional tests
+* That's pretty much why we write tests
+* Start experimenting with ATTACH configs and full-namespace database references for DuckDB 0.7.0
+* Define the attachment configuration options on the DuckDBCredentials class
+* black
+* Getting the code ready for DuckDB 0.7.0 and dbt 1.4.0
+* Bump mypy from 0.991 to 1.0.0
+* remove extra import
+* cleanup test
+* use pyarrow instead of pandas where possible. Ensure import before isinstance checks. Add pyarrow as dev dependency
+* add usage of register\_upstream\_external\_models macro to README
+* replace model-level macro with an on-run-start hook that materializes all models upstream of the selected ones
+* Add in some lru\_cache to limit the hit from these creds lookups on small runs
+* fix bug
+* Use sts to verify the credentials are correct/work
+* fix that precommit error
+* Add in support for getting AWS creds using the AWS credentials chain
+* Bump tests
+* Keep at 3.8 for mypy
+* Move back to 3.10 for code quality check
+* Change main python version
+* Stringify Python versions
+* add new python versions to actiosn
+* Add 3.10 and 3.11 support
+* Match refactored class names from DBT 1.4.0
+* Register views for upstream external models
+* use the cursor with the stored credentials for python models rather than the bare connection
+* Bump dbt-tests-adapter from 1.3.1 to 1.3.2
+* fix that
+* Update/modernize the duckdb\_\_load\_csv\_rows macro impl
+* Also format the ext location string with the schema for further help with boilerplate
+* and that
+* see if this magically fixes things
+* Bump black from 22.10.0 to 22.12.0
+* Use better, non-regex based syntax for handling the limit case inside of the listagg macro
+* 1.3.3 release
+* Work around pandas dependency on parameter bindings that feature datetime instances
+* precommit stuff
+* Oops not what I meant
+* Use an importlib-based approach to loading and executing dbt Python models
+* Bump mypy from 0.990 to 0.991
+* Bump dbt-tests-adapter from 1.3.0 to 1.3.1
+* well thats just head-slappingly stupid of me
+* okay fine i'll default to pandas instead
+* make this CI friendly
+* Support DuckDBPyRelation as a return type from Python models
+* huh not sure how that got there
+* Allow dbt-duckdb to work with versions after 0.5.0, including the new 0.6.0
+* Bump mypy from 0.982 to 0.990
+* Add render support for all of the string config options for external materializations
+
+v1.3.1
+------
+
+* Bump to 1.3.1 and release that
+* fix: run external everytime (#51)
+* Fix upgrading pip (#53)
+* fix: disable upgrading pip in github action (#52)
+* bit more polish
+* typos and formatting
+* trailing ws
+* Docs update for the 1.3.0 release
+* Now with tests for sources with an external location
+* try whistling this
+* fix not in
+* import ordering
+* Another rev at this, adjusting things somewhat to allow for templating external locations at the source level
+* Redo this as a jinja templated var
+* checkpoint this for now
+* Minimal amount of effort required to make external locations work for dbt-duckdb sources
+* feat: add support for glue catalog (#47)
+* okay finally have my black settings right
+* Add an external\_root setting for the DuckDB profile as a location to write external files to when no location is specified explicitly
+* fix: default delimiter changed to comma
+* fix: remove unused macro create\_view\_loacation (#45)
+* Add external location macro (#44)
+* feat: add support for external materialization (#35)
+* Bump freezegun from 0.3.12 to 1.2.2 (#41)
+* Bump actions/download-artifact from 2 to 3 (#40)
+* fix: development env requirements
+* feat: add dependabot (#39)
+* patch the COLUMNS\_EQUAL\_SQL template to not use the same identifiers as the tested relations in the TestConcurrency test cases
+* style: fix missing import ordering (#36)
+* feat: add support for python models (#28)
+* feat: add new functional tests from 1.3.0 (#32)
+
+v1.2.3
+------
+
+* Black wit longer lines
+* Ensure that we always keep a connection open when we're running dbt-duckdb in-memory
+* fix: black formatting
+* fix: running action
+* fix: ignore type of \_\_path\_\_
+* feat: adapt to scaffolding template
+* Generalize the extensions/settings config for DuckDB and update the README to reflect
+* Reference count the open connections and close the parent connection when they are all closed
+* Move creds fetch outside of the lock
+* black + README updates
+* Make multiple threads work with dbt-duckdb
+* Update README
+* Update README
+* Update to 1.2.0 as the release version
+* Okay now S3 stuff works correctly, yay
+* Use the cursor (aka connection) associated with the connection.handle instead of the parent one from duckdb.connect
+* add in extension loading support
+* format the tests
+* Update to target real dbt 1.2.0
+* Add in support for the cross-db util impls for DuckDB and tests for the same
+* WIP for 1.2.0rc1; may be basis of dbt-duckdb 1.2.0
+* update CHANGELOG
+* Version bump to explicitly check that the profile is only using a single thread for dbt-duckdb
+* Enforce the single-threaded profile config for dbt-duckdb and note it in the README
+* Updated CHANGELOG
+* Fix a bunch of stuff and get ready for the next version
+* Remove old test spec
+* Now with adapter specific naming
+* Use the new dbt adapter test library
+* Prep version bump for 1.1.2 release
+* Update CHANGELOG
+* Exclude duckdb 0.4.0 from compatible versions
+* Align with minor version of dbt-core
+* and minor version bump
+* Fix that typo
+* Define a CHANGELOG
+* Upgrade to duckdb 0.3.2; refactor connections now that we can support dbt threads correctly
+* Be more explicit about erors in model queries/give more helpful debug info
+* Less code == good
+* tiny version bump
+* Fix this and that
+* Fix this so that duckdb shows up as a supported plugin when you run dbt --version
+* black all the things
+* Add Apache License; fixes #4
+* Simplify DuckDBConnectionWrapper logic
+* Support for dbt 0.20.1
+* Support for duckdb 0.2.8. Fixes #2
+* Update for PyPI usage with released version of duckdb 0.2.2. Fixes #1
+* now everything works, yay
+* enable snapshot tests now that update..from is supported
+* No longer need to worry about closing these cursors explicitly
+* how bad i am at stuff
+* Update README.md
+* Instructions for the creds config
+* Add default values for all of the credential fields so you don't usually have to specify anything besides the path
+* Give useful install instructions for local dev
+* \_\_init\_\_.py infra so pip install . will work
+* Re-order the operations in the snapshot\_merge impl
+* Enable more of the standard tests by default
+* hack in a version of snapshot merge that I can (eventually) make work with duckdb
+* Make the tests get a little bit further
+* Add a block to close any open cursors returned by the add\_query method
+* Some more macros we needed
+* acknowledge passed in schemas
+* first cut at the duckdb catalog macro
+* much less awful
+* Latest and greatest
+* Checkpointing some more work here
+* closer to working
+* Weaken version reqs for the time being
+* Initial commit of dbt-duckdb

--- a/dbt/adapters/duckdb/connections.py
+++ b/dbt/adapters/duckdb/connections.py
@@ -130,5 +130,10 @@ class DuckDBConnectionManager(SQLConnectionManager):
             auto_begin = False
         return super().execute(sql, auto_begin, fetch, limit)
 
+    def commit_if_has_connection(self) -> None:
+        connection = self.get_if_exists()
+        if connection and connection.transaction_open:
+            self.commit()
+
 
 atexit.register(DuckDBConnectionManager.close_all_connections)

--- a/dbt/adapters/duckdb/credentials.py
+++ b/dbt/adapters/duckdb/credentials.py
@@ -241,6 +241,8 @@ class DuckDBCredentials(Credentials):
 
         # Build set of ducklake database names for efficient lookup
         self._ducklake_dbs = set()
+        # Build set of iceberg REST catalog database names for efficient lookup
+        self._iceberg_dbs = set()
 
         if self.is_ducklake or "ducklake:" in self.path.lower():
             self._ducklake_dbs.add(self.path_derived_database_name(self.path))
@@ -250,6 +252,7 @@ class DuckDBCredentials(Credentials):
                 is_ducklake_flag = getattr(attachment, "is_ducklake", None)
                 path = getattr(attachment, "path", None)
                 alias = getattr(attachment, "alias", None)
+                attachment_type = getattr(attachment, "type", None)
 
                 # Detect ducklake by explicit type, or by path scheme. Be lenient on case.
                 if (isinstance(is_ducklake_flag, bool) and is_ducklake_flag) or (
@@ -259,6 +262,12 @@ class DuckDBCredentials(Credentials):
                         self._ducklake_dbs.add(alias)
                     else:
                         self._ducklake_dbs.add(self.path_derived_database_name(path))
+
+                if isinstance(attachment_type, str) and attachment_type.lower() == "iceberg":
+                    if alias:
+                        self._iceberg_dbs.add(alias)
+                    else:
+                        self._iceberg_dbs.add(self.path_derived_database_name(path))
 
         # Add MotherDuck plugin if the path is a MotherDuck database
         # and plugin was not specified in profile.yml

--- a/dbt/adapters/duckdb/impl.py
+++ b/dbt/adapters/duckdb/impl.py
@@ -160,6 +160,14 @@ class DuckDBAdapter(SQLAdapter):
         return relation.database in self.config.credentials._ducklake_dbs
 
     @available
+    def is_iceberg(self, relation: DuckDBRelation) -> bool:
+        """Check if a relation's database is backed by an iceberg REST catalog attachment."""
+        if not relation or not relation.database:
+            return False
+
+        return relation.database in self.config.credentials._iceberg_dbs
+
+    @available
     def convert_datetimes_to_strs(self, table: "agate.Table") -> "agate.Table":
         import agate
 

--- a/dbt/include/duckdb/macros/adapters.sql
+++ b/dbt/include/duckdb/macros/adapters.sql
@@ -297,7 +297,7 @@ def materialize(df, con):
 
 {% macro duckdb__drop_relation(relation) -%}
   {% call statement('drop_relation', auto_begin=False) -%}
-    {% if adapter.is_ducklake(relation) %}
+    {% if adapter.is_ducklake(relation) or adapter.is_iceberg(relation) %}
       drop {{ relation.type }} if exists {{ relation }}
     {% else %}
       drop {{ relation.type }} if exists {{ relation }} cascade

--- a/dbt/include/duckdb/macros/adapters.sql
+++ b/dbt/include/duckdb/macros/adapters.sql
@@ -307,6 +307,10 @@ def materialize(df, con):
 
 {% macro duckdb__rename_relation(from_relation, to_relation) -%}
   {% set target_name = adapter.quote_as_configured(to_relation.identifier, 'identifier') %}
+  {%- if adapter.is_iceberg(to_relation) -%}
+    {#-- Iceberg REST: CTAS and ALTER...RENAME cannot share a transaction; commit first --#}
+    {{ adapter.commit() }}
+  {%- endif -%}
   {% call statement('rename_relation') -%}
     alter {{ to_relation.type }} {{ from_relation }} rename to {{ target_name }}
   {%- endcall %}

--- a/dbt/include/duckdb/macros/adapters.sql
+++ b/dbt/include/duckdb/macros/adapters.sql
@@ -307,7 +307,7 @@ def materialize(df, con):
 
 {% macro duckdb__rename_relation(from_relation, to_relation) -%}
   {% set target_name = adapter.quote_as_configured(to_relation.identifier, 'identifier') %}
-  {%- if adapter.is_iceberg(to_relation) -%}
+  {%- if adapter.is_iceberg(from_relation) -%}
     {#-- Iceberg REST: CTAS and ALTER...RENAME cannot share a transaction; commit first --#}
     {{ adapter.commit() }}
   {%- endif -%}

--- a/dbt/include/duckdb/macros/adapters.sql
+++ b/dbt/include/duckdb/macros/adapters.sql
@@ -254,25 +254,39 @@ def materialize(df, con):
 {% endmacro %}
 
 {% macro duckdb__get_columns_in_relation(relation) -%}
-  {% call statement('get_columns_in_relation', fetch_result=True) %}
+  {% if adapter.is_iceberg(relation) %}
+    {#-- information_schema.columns returns incorrect metadata for Iceberg REST
+         catalog tables (column names come back as "__"). Use DESCRIBE instead. --#}
+    {% call statement('get_columns_in_relation', fetch_result=True) %}
       select
           column_name,
-          data_type,
-          character_maximum_length,
-          numeric_precision,
-          numeric_scale
+          column_type                as data_type,
+          null::integer              as character_maximum_length,
+          null::integer              as numeric_precision,
+          null::integer              as numeric_scale
+      from (describe {{ relation }})
+    {% endcall %}
+  {% else %}
+    {% call statement('get_columns_in_relation', fetch_result=True) %}
+        select
+            column_name,
+            data_type,
+            character_maximum_length,
+            numeric_precision,
+            numeric_scale
 
-      from system.information_schema.columns
-      where table_name = '{{ relation.identifier }}'
-      {% if relation.schema %}
-      and lower(table_schema) = '{{ relation.schema | lower }}'
-      {% endif %}
-      {% if relation.database %}
-      and lower(table_catalog) = '{{ relation.database | lower }}'
-      {% endif %}
-      order by ordinal_position
+        from system.information_schema.columns
+        where table_name = '{{ relation.identifier }}'
+        {% if relation.schema %}
+        and lower(table_schema) = '{{ relation.schema | lower }}'
+        {% endif %}
+        {% if relation.database %}
+        and lower(table_catalog) = '{{ relation.database | lower }}'
+        {% endif %}
+        order by ordinal_position
 
-  {% endcall %}
+    {% endcall %}
+  {% endif %}
   {% set table = load_result('get_columns_in_relation').table %}
   {{ return(sql_convert_columns_in_relation(table)) }}
 {% endmacro %}

--- a/docs/table-materialization-drift.md
+++ b/docs/table-materialization-drift.md
@@ -1,0 +1,315 @@
+# Table Materialization Drift: dbt-duckdb vs Global Project
+
+Goal: identify every difference between `dbt/include/duckdb/macros/materializations/table.sql`
+and the dbt-core global project default, then assess whether each difference can be moved
+into a dispatched sub-macro so the materialization itself shrinks toward the default.
+
+---
+
+## Side-by-side summary
+
+| # | Difference | dbt-duckdb | global project |
+|---|---|---|---|
+| 1 | Materialization signature | `adapter="duckdb", supported_languages=['sql','python']` | `default` (SQL only) |
+| 2 | Language variable | `{% set language = model['language'] %}` | none |
+| 3 | Statement call | `{% call statement('main', language=language, auto_begin=not skip_auto_begin) %}` | `{% call statement('main') %}` |
+| 4 | SQL-generation macro | `create_table_as(…, language, partitioned_by, sorted_by)` | `get_create_table_as_sql(False, relation, sql)` |
+| 5 | Partitioning / sorting | reads config, passes to `create_table_as` | not present |
+| 6 | `skip_auto_begin` | set for DuckLake + partitions/sorts | not present |
+| 7 | DuckLake docs timing | `persist_docs` deferred to after `adapter.commit()` + second commit | `persist_docs` always inside transaction |
+| 8 | Index drop before first rename | `drop_indexes_on_relation(existing_relation)` before rename | not present |
+| 9 | `create_indexes` placement | on **target** after both renames | on **intermediate** before renames |
+| 10 | Re-check of `existing_relation` | missing | `load_cached_relation(existing_relation)` re-checked before first rename |
+
+---
+
+## Per-difference analysis
+
+### 1 & 2 — `supported_languages` + `language` variable
+
+**Movable? No — structural.**
+
+`supported_languages` must be in the materialization signature; dbt-core uses it to decide
+whether to route Python models here. `language=language` on the `statement()` call changes
+the execution mode (Python vs SQL). Neither can be expressed in a sub-macro.
+
+This is the one irreducible reason dbt-duckdb needs its own `table` materialization at all.
+
+---
+
+### 3 — `auto_begin=not skip_auto_begin` on the statement call
+
+**Movable? No — structural (but scope can shrink).**
+
+`auto_begin` is a parameter of `{% call statement() %}`, not of the SQL content. It cannot
+be controlled from inside `create_table_as` or any other sub-macro.
+
+However, `skip_auto_begin` is only set for DuckLake + partitions/sorts (difference #6).
+If partitioned_by/sorted_by move inside `duckdb__create_table_as` (see #5 below), this
+flag and the `auto_begin` override would need to stay but could be simplified:
+
+```jinja
+{%- set skip_auto_begin = adapter.is_ducklake(target_relation)
+                          and config.get('partitioned_by') or config.get('sorted_by') -%}
+```
+
+---
+
+### 4 — `get_create_table_as_sql` vs `create_table_as`
+
+**Movable? Yes — already dispatched, just uses a different dispatch path.**
+
+The global project calls `get_create_table_as_sql()` → dispatches to
+`adapter__get_create_table_as_sql`. dbt-duckdb calls `create_table_as()` → dispatches to
+`duckdb__create_table_as`. These are functionally equivalent dispatch mechanisms.
+
+The dbt-duckdb version also passes `language`, `partitioned_by`, and `sorted_by` as extra
+arguments. Once #5 is resolved (args moved into the macro via config), both callers
+could use the same `get_create_table_as_sql` dispatch and the materialization call would
+align with the global project:
+
+```jinja
+{# goal state #}
+{% call statement('main') -%}
+  {{ get_create_table_as_sql(False, intermediate_relation, compiled_code) }}
+{%- endcall %}
+```
+
+(Python language support would still need `language=language` on the statement call.)
+
+---
+
+### 5 — `partitioned_by` / `sorted_by` variables
+
+**Movable? Yes — read from `config` inside `duckdb__create_table_as`.**
+
+Currently the materialization computes them and passes them as arguments:
+
+```jinja
+{%- set partitioned_by = duckdb__get_partitioned_by(target_relation, false) -%}
+{%- set sorted_by = duckdb__get_sorted_by(target_relation, false) -%}
+…
+{{- create_table_as(False, intermediate_relation, compiled_code, language,
+      partitioned_by=partitioned_by, sorted_by=sorted_by) }}
+```
+
+`duckdb__create_table_as` could read them directly from `config` (same as
+`duckdb__get_partitioned_by` already does internally), removing them from the
+materialization entirely:
+
+```jinja
+{% macro duckdb__create_table_as(temporary, relation, compiled_code, language='sql', …) %}
+  {%- set partitioned_by = duckdb__get_partitioned_by(relation, temporary) -%}
+  {%- set sorted_by     = duckdb__get_sorted_by(relation, temporary) -%}
+  …
+{% endmacro %}
+```
+
+The `skip_auto_begin` flag for DuckLake+partitions would also move — but since it
+controls `auto_begin` on the `statement()` call (see #3), the materialization would
+need to keep the flag and read it a different way, e.g.:
+
+```jinja
+{%- set skip_auto_begin = adapter.needs_separate_ctas_transaction(target_relation) -%}
+```
+
+where `needs_separate_ctas_transaction` is a new `@available` method that encapsulates
+the DuckLake+partition check.
+
+---
+
+### 6 — `skip_auto_begin` (DuckLake + partitions/sorts)
+
+See #3 and #5 above. Can be simplified once partitioned_by/sorted_by move into
+`duckdb__create_table_as`, but the `auto_begin` override itself stays structural.
+
+---
+
+### 7 — DuckLake post-commit `persist_docs`
+
+**Movable? Yes — override `duckdb__persist_docs`.**
+
+Currently the materialization has conditional logic:
+
+```jinja
+{% if not post_commit_ducklake_docs %}
+  {% do persist_docs(target_relation, model) %}
+{% endif %}
+{{ adapter.commit() }}
+{% if post_commit_ducklake_docs %}
+  {% do persist_docs(target_relation, model) %}
+  {{ adapter.commit() }}
+{% endif %}
+```
+
+This can move entirely into a `duckdb__persist_docs` override that commits first when
+needed, letting the materialization use the global project's simple one-liner:
+
+```jinja
+{% macro duckdb__persist_docs(relation, model, for_relation=true, for_columns=true) %}
+  {% if adapter.is_ducklake(relation) %}
+    {{ adapter.commit() }}
+  {% endif %}
+  {{ return(default__persist_docs(relation, model,
+        for_relation=for_relation, for_columns=for_columns)) }}
+{% endmacro %}
+```
+
+The `adapter.commit()` at the end of the materialization would then be a no-op for
+DuckLake (transaction already closed), which is safe.
+
+**Caveat**: the second `adapter.commit()` after DuckLake persist_docs is for committing
+the docs-update itself. That still needs to happen. Options:
+- call `adapter.commit()` inside `duckdb__persist_docs` after the docs update too, or
+- accept that the final `adapter.commit()` in the materialization handles it.
+
+---
+
+### 8 — `drop_indexes_on_relation` before first rename
+
+**Movable? Yes — move into `duckdb__rename_relation`.**
+
+The global project does not drop indexes before renaming. dbt-duckdb added this to avoid
+dependency errors when renaming a table that has indexes in some DuckDB versions.
+
+Moving it into `duckdb__rename_relation` removes it from the materialization and
+automatically protects every materialization (table, incremental, external):
+
+```jinja
+{% macro duckdb__rename_relation(from_relation, to_relation) -%}
+  {% set target_name = adapter.quote_as_configured(to_relation.identifier, 'identifier') %}
+  {%- if adapter.is_iceberg(from_relation) and adapter.has_open_transaction() -%}
+    {{ adapter.commit() }}
+  {%- else -%}
+    {% do drop_indexes_on_relation(from_relation) %}
+  {%- endif -%}
+  {% call statement('rename_relation') -%}
+    alter {{ to_relation.type }} {{ from_relation }} rename to {{ target_name }}
+  {%- endcall %}
+{% endmacro %}
+```
+
+(The `else` branch avoids redundantly dropping indexes on Iceberg relations, which
+don't have DuckDB-style indexes anyway.)
+
+---
+
+### 9 — `create_indexes` placement
+
+**Movable? Yes — consequence of moving #8 into `rename_relation`.**
+
+Global project creates indexes on the *intermediate* relation before renames, then the
+rename carries the indexes along to the target name. dbt-duckdb drops indexes on the
+existing relation, renames, then creates indexes on the final target — because the drop
+was needed to make the first rename safe.
+
+Once the index drop moves into `duckdb__rename_relation` (#8), the materialization could
+align with the global project and call `create_indexes(intermediate_relation)` before the
+renames. Indexes would then travel with the table through both renames.
+
+This removes the `{% do create_indexes(target_relation) %}` call that currently sits after
+the renames in dbt-duckdb.
+
+---
+
+### 10 — Missing re-check of `existing_relation` before first rename
+
+**Action: align with global project (this is a gap, not a feature).**
+
+The global project defensively re-checks `existing_relation` immediately before the first
+rename in case it was dropped between setup and execution:
+
+```jinja
+{% set existing_relation = load_cached_relation(existing_relation) %}
+{% if existing_relation is not none %}
+    {{ adapter.rename_relation(existing_relation, backup_relation) }}
+{% endif %}
+```
+
+dbt-duckdb skips this re-check. It should be added.
+
+---
+
+## Proposed goal state for `table.sql`
+
+After all movable differences are extracted, the dbt-duckdb materialization shrinks to:
+
+```jinja
+{% materialization table, adapter="duckdb", supported_languages=['sql', 'python'] %}
+
+  {%- set language = model['language'] -%}
+  {%- set existing_relation = load_cached_relation(this) -%}
+  {%- set target_relation = this.incorporate(type='table') %}
+  {%- set intermediate_relation = make_intermediate_relation(target_relation) -%}
+  {%- set preexisting_intermediate_relation = load_cached_relation(intermediate_relation) -%}
+  {%- set backup_relation_type = 'table' if existing_relation is none else existing_relation.type -%}
+  {%- set backup_relation = make_backup_relation(target_relation, backup_relation_type) -%}
+  {%- set preexisting_backup_relation = load_cached_relation(backup_relation) -%}
+  {% set grant_config = config.get('grants') %}
+
+  {{ drop_relation_if_exists(preexisting_intermediate_relation) }}
+  {{ drop_relation_if_exists(preexisting_backup_relation) }}
+
+  {{ run_hooks(pre_hooks, inside_transaction=False) }}
+
+  -- `BEGIN` happens here:
+  {{ run_hooks(pre_hooks, inside_transaction=True) }}
+
+  {%- set skip_auto_begin = adapter.needs_separate_ctas_transaction(target_relation) -%}
+
+  -- build model
+  {% call statement('main', language=language, auto_begin=not skip_auto_begin) -%}
+    {{ get_create_table_as_sql(False, intermediate_relation, compiled_code) }}
+  {%- endcall %}
+
+  {% do create_indexes(intermediate_relation) %}
+
+  -- cleanup
+  {% if existing_relation is not none %}
+    {% set existing_relation = load_cached_relation(existing_relation) %}
+    {% if existing_relation is not none %}
+      {{ adapter.rename_relation(existing_relation, backup_relation) }}
+    {% endif %}
+  {% endif %}
+
+  {{ adapter.rename_relation(intermediate_relation, target_relation) }}
+
+  {{ run_hooks(post_hooks, inside_transaction=True) }}
+
+  {% set should_revoke = should_revoke(existing_relation, full_refresh_mode=True) %}
+  {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
+
+  {% do persist_docs(target_relation, model) %}
+
+  -- `COMMIT` happens here
+  {{ adapter.commit() }}
+
+  {{ drop_relation_if_exists(backup_relation) }}
+
+  {{ run_hooks(post_hooks, inside_transaction=False) }}
+
+  {{ return({'relations': [target_relation]}) }}
+{% endmaterialization %}
+```
+
+The only remaining differences from the global project default are:
+- `adapter="duckdb", supported_languages=['sql', 'python']` (line 1) — irreducible
+- `language=language` on the statement call — irreducible (Python support)
+- `auto_begin=not skip_auto_begin` + `skip_auto_begin` variable — irreducible as long as
+  DuckLake partition/sort CTAS requires a separate transaction
+- `get_create_table_as_sql` is called with `compiled_code` not `sql` — these are the
+  same value; aligning variable names is trivial
+
+---
+
+## Work breakdown for a follow-on PR
+
+| Task | Macro to change | Effort |
+|---|---|---|
+| Move index drop before rename | `duckdb__rename_relation` | small |
+| Move Iceberg commit before rename (already done) | `duckdb__rename_relation` | done |
+| Move DuckLake post-commit docs | new `duckdb__persist_docs` | small |
+| Move partitioned_by/sorted_by into create_table_as | `duckdb__create_table_as` | medium |
+| Add `needs_separate_ctas_transaction()` adapter method | `impl.py` | small |
+| Add defensive re-check of `existing_relation` | `table.sql` | trivial |
+| Align `create_indexes` placement (intermediate not target) | `table.sql` | small |

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,3 +7,4 @@ testpaths =
     tests/unit
 markers =
     skip_profile(profile)
+    requires_lakekeeper: mark test as requiring a running lakekeeper Iceberg REST catalog

--- a/tests/functional/adapter/test_iceberg_lakekeeper_integration.py
+++ b/tests/functional/adapter/test_iceberg_lakekeeper_integration.py
@@ -1,0 +1,202 @@
+"""Functional integration tests for Iceberg REST catalog (lakekeeper) with dbt-duckdb.
+
+Tests are skipped automatically when lakekeeper is not reachable.
+
+Configuration via environment variables:
+  LAKEKEEPER_URL       Base URL of the lakekeeper server (default: http://localhost:8181)
+  LAKEKEEPER_WAREHOUSE Iceberg warehouse name to use (default: demo)
+
+The tests verify that the table materialization correctly separates CTAS and
+ALTER...RENAME into different transactions, which is required by DuckDB's Iceberg
+extension — CTAS and ALTER RENAME cannot share a transaction against a REST catalog.
+"""
+import os
+
+import pytest
+from dbt.tests.util import run_dbt
+
+
+_LAKEKEEPER_URL = os.environ.get("LAKEKEEPER_URL", "http://localhost:8181")
+_LAKEKEEPER_WAREHOUSE = os.environ.get("LAKEKEEPER_WAREHOUSE", "demo")
+
+
+def _lakekeeper_available() -> bool:
+    try:
+        import requests
+
+        resp = requests.get(f"{_LAKEKEEPER_URL}/catalog/v1/config", timeout=3)
+        return resp.ok
+    except Exception:
+        return False
+
+
+models__simple_table_sql = """
+{{ config(materialized='table', database='iceberg_catalog') }}
+select 1 as id, 'hello' as msg
+union all
+select 2 as id, 'world' as msg
+"""
+
+models__incremental_sql = """
+{{ config(
+    materialized='incremental',
+    database='iceberg_catalog',
+    unique_key='id',
+) }}
+
+{% if is_incremental() %}
+select 3 as id, 'iceberg' as msg
+{% else %}
+select 1 as id, 'hello' as msg
+union all
+select 2 as id, 'world' as msg
+{% endif %}
+"""
+
+
+@pytest.mark.skip_profile("buenavista", "md")
+class TestIcebergLakekeeperTableMaterialization:
+    """Table materialization against a lakekeeper Iceberg REST catalog.
+
+    Verifies that:
+    1. First run: CTAS creates the intermediate table and rename moves it into place.
+    2. Second run: the intermediate CTAS commits before the rename, satisfying the
+       Iceberg constraint that CTAS and ALTER...RENAME cannot share a transaction.
+    """
+
+    @pytest.fixture(scope="class")
+    def lakekeeper_url(self):
+        if not _lakekeeper_available():
+            pytest.skip(f"lakekeeper not reachable at {_LAKEKEEPER_URL}")
+        return _LAKEKEEPER_URL
+
+    @pytest.fixture(scope="class")
+    def profiles_config_update(self, dbt_profile_target, lakekeeper_url):
+        target = dict(dbt_profile_target)
+        target["path"] = target.get("path", ":memory:")
+        target["attach"] = [
+            {
+                "alias": "iceberg_catalog",
+                "path": _LAKEKEEPER_WAREHOUSE,
+                "type": "iceberg",
+                "options": {
+                    "endpoint": f"{lakekeeper_url}/catalog",
+                    "token": "",
+                },
+            }
+        ]
+        return {"test": {"outputs": {"dev": target}, "target": "dev"}}
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "simple_table.sql": models__simple_table_sql,
+        }
+
+    def test_first_run_creates_table(self, project):
+        """First run: intermediate relation is created, then renamed to target."""
+        result = run_dbt(["run", "--select", "simple_table"], expect_pass=True)
+        assert len(result.results) == 1
+        assert result.results[0].status.value == "success"
+
+        row_count = project.run_sql(
+            f"select count(*) from iceberg_catalog.{project.test_schema}.simple_table",
+            fetch="one",
+        )[0]
+        assert row_count == 2
+
+    def test_second_run_rename_in_separate_transaction(self, project):
+        """Second run: CTAS commits, then rename opens a new transaction.
+
+        This is the critical path — without skip_auto_begin for iceberg, DuckDB
+        raises an error because CTAS and ALTER...RENAME share a transaction.
+        """
+        result = run_dbt(["run", "--select", "simple_table"], expect_pass=True)
+        assert len(result.results) == 1
+        assert result.results[0].status.value == "success"
+
+        row_count = project.run_sql(
+            f"select count(*) from iceberg_catalog.{project.test_schema}.simple_table",
+            fetch="one",
+        )[0]
+        assert row_count == 2
+
+    def test_full_refresh_rename_in_separate_transaction(self, project):
+        """--full-refresh exercises the incremental → full-replace rename path."""
+        result = run_dbt(
+            ["run", "--select", "simple_table", "--full-refresh"],
+            expect_pass=True,
+        )
+        assert len(result.results) == 1
+        assert result.results[0].status.value == "success"
+
+        row_count = project.run_sql(
+            f"select count(*) from iceberg_catalog.{project.test_schema}.simple_table",
+            fetch="one",
+        )[0]
+        assert row_count == 2
+
+
+@pytest.mark.skip_profile("buenavista", "md")
+class TestIcebergLakekeeperIncrementalMaterialization:
+    """Incremental materialization against a lakekeeper Iceberg REST catalog."""
+
+    @pytest.fixture(scope="class")
+    def lakekeeper_url(self):
+        if not _lakekeeper_available():
+            pytest.skip(f"lakekeeper not reachable at {_LAKEKEEPER_URL}")
+        return _LAKEKEEPER_URL
+
+    @pytest.fixture(scope="class")
+    def profiles_config_update(self, dbt_profile_target, lakekeeper_url):
+        target = dict(dbt_profile_target)
+        target["path"] = target.get("path", ":memory:")
+        target["attach"] = [
+            {
+                "alias": "iceberg_catalog",
+                "path": _LAKEKEEPER_WAREHOUSE,
+                "type": "iceberg",
+                "options": {
+                    "endpoint": f"{lakekeeper_url}/catalog",
+                    "token": "",
+                },
+            }
+        ]
+        return {"test": {"outputs": {"dev": target}, "target": "dev"}}
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "incremental_model.sql": models__incremental_sql,
+        }
+
+    def test_incremental_first_run(self, project):
+        result = run_dbt(["run", "--select", "incremental_model"], expect_pass=True)
+        assert len(result.results) == 1
+        row_count = project.run_sql(
+            f"select count(*) from iceberg_catalog.{project.test_schema}.incremental_model",
+            fetch="one",
+        )[0]
+        assert row_count == 2
+
+    def test_incremental_second_run_appends(self, project):
+        result = run_dbt(["run", "--select", "incremental_model"], expect_pass=True)
+        assert len(result.results) == 1
+        row_count = project.run_sql(
+            f"select count(*) from iceberg_catalog.{project.test_schema}.incremental_model",
+            fetch="one",
+        )[0]
+        assert row_count == 3
+
+    def test_incremental_full_refresh(self, project):
+        """Full-refresh incremental exercises the CTAS+rename transaction split."""
+        result = run_dbt(
+            ["run", "--select", "incremental_model", "--full-refresh"],
+            expect_pass=True,
+        )
+        assert len(result.results) == 1
+        row_count = project.run_sql(
+            f"select count(*) from iceberg_catalog.{project.test_schema}.incremental_model",
+            fetch="one",
+        )[0]
+        assert row_count == 2

--- a/tests/functional/adapter/test_iceberg_lakekeeper_integration.py
+++ b/tests/functional/adapter/test_iceberg_lakekeeper_integration.py
@@ -184,13 +184,6 @@ class TestIcebergLakekeeperIncrementalMaterialization:
         )[0]
         assert row_count == 2
 
-    @pytest.mark.xfail(
-        reason=(
-            "DuckDB Iceberg: information_schema.columns returns '__' for Iceberg table "
-            "columns, breaking get_columns_in_relation. Tracked upstream in duckdb/duckdb-iceberg."
-        ),
-        strict=False,
-    )
     def test_incremental_second_run_appends(self, project):
         result = run_dbt(["run", "--select", "incremental_model"], expect_pass=True)
         assert len(result.results) == 1

--- a/tests/functional/adapter/test_iceberg_lakekeeper_integration.py
+++ b/tests/functional/adapter/test_iceberg_lakekeeper_integration.py
@@ -11,21 +11,20 @@ ALTER...RENAME into different transactions, which is required by DuckDB's Iceber
 extension — CTAS and ALTER RENAME cannot share a transaction against a REST catalog.
 """
 import os
+import urllib.error
+import urllib.request
 
 import pytest
 from dbt.tests.util import run_dbt
 
+_DEFAULT_LAKEKEEPER_URL = "http://localhost:8181"
+_DEFAULT_LAKEKEEPER_WAREHOUSE = "demo"
 
-_LAKEKEEPER_URL = os.environ.get("LAKEKEEPER_URL", "http://localhost:8181")
-_LAKEKEEPER_WAREHOUSE = os.environ.get("LAKEKEEPER_WAREHOUSE", "demo")
 
-
-def _lakekeeper_available() -> bool:
+def _lakekeeper_available(url: str) -> bool:
     try:
-        import requests
-
-        resp = requests.get(f"{_LAKEKEEPER_URL}/catalog/v1/config", timeout=3)
-        return resp.ok
+        urllib.request.urlopen(f"{url}/catalog/v1/config", timeout=3)
+        return True
     except Exception:
         return False
 
@@ -66,18 +65,20 @@ class TestIcebergLakekeeperTableMaterialization:
 
     @pytest.fixture(scope="class")
     def lakekeeper_url(self):
-        if not _lakekeeper_available():
-            pytest.skip(f"lakekeeper not reachable at {_LAKEKEEPER_URL}")
-        return _LAKEKEEPER_URL
+        url = os.environ.get("LAKEKEEPER_URL", _DEFAULT_LAKEKEEPER_URL)
+        if not _lakekeeper_available(url):
+            pytest.skip(f"lakekeeper not reachable at {url}")
+        return url
 
     @pytest.fixture(scope="class")
     def profiles_config_update(self, dbt_profile_target, lakekeeper_url):
+        warehouse = os.environ.get("LAKEKEEPER_WAREHOUSE", _DEFAULT_LAKEKEEPER_WAREHOUSE)
         target = dict(dbt_profile_target)
         target["path"] = target.get("path", ":memory:")
         target["attach"] = [
             {
                 "alias": "iceberg_catalog",
-                "path": _LAKEKEEPER_WAREHOUSE,
+                "path": warehouse,
                 "type": "iceberg",
                 "options": {
                     "endpoint": f"{lakekeeper_url}/catalog",
@@ -143,18 +144,20 @@ class TestIcebergLakekeeperIncrementalMaterialization:
 
     @pytest.fixture(scope="class")
     def lakekeeper_url(self):
-        if not _lakekeeper_available():
-            pytest.skip(f"lakekeeper not reachable at {_LAKEKEEPER_URL}")
-        return _LAKEKEEPER_URL
+        url = os.environ.get("LAKEKEEPER_URL", _DEFAULT_LAKEKEEPER_URL)
+        if not _lakekeeper_available(url):
+            pytest.skip(f"lakekeeper not reachable at {url}")
+        return url
 
     @pytest.fixture(scope="class")
     def profiles_config_update(self, dbt_profile_target, lakekeeper_url):
+        warehouse = os.environ.get("LAKEKEEPER_WAREHOUSE", _DEFAULT_LAKEKEEPER_WAREHOUSE)
         target = dict(dbt_profile_target)
         target["path"] = target.get("path", ":memory:")
         target["attach"] = [
             {
                 "alias": "iceberg_catalog",
-                "path": _LAKEKEEPER_WAREHOUSE,
+                "path": warehouse,
                 "type": "iceberg",
                 "options": {
                     "endpoint": f"{lakekeeper_url}/catalog",

--- a/tests/functional/adapter/test_iceberg_lakekeeper_integration.py
+++ b/tests/functional/adapter/test_iceberg_lakekeeper_integration.py
@@ -23,7 +23,7 @@ _DEFAULT_LAKEKEEPER_WAREHOUSE = "demo"
 
 def _lakekeeper_available(url: str) -> bool:
     try:
-        urllib.request.urlopen(f"{url}/catalog/v1/config", timeout=3)
+        urllib.request.urlopen(f"{url}/management/v1/warehouse", timeout=3)
         return True
     except Exception:
         return False
@@ -40,7 +40,7 @@ models__incremental_sql = """
 {{ config(
     materialized='incremental',
     database='iceberg_catalog',
-    unique_key='id',
+    incremental_strategy='append',
 ) }}
 
 {% if is_incremental() %}
@@ -71,9 +71,10 @@ class TestIcebergLakekeeperTableMaterialization:
         return url
 
     @pytest.fixture(scope="class")
-    def profiles_config_update(self, dbt_profile_target, lakekeeper_url):
+    def profiles_config_update(self, dbt_profile_target, lakekeeper_url, unique_schema):
         warehouse = os.environ.get("LAKEKEEPER_WAREHOUSE", _DEFAULT_LAKEKEEPER_WAREHOUSE)
         target = dict(dbt_profile_target)
+        target["schema"] = unique_schema
         target["path"] = target.get("path", ":memory:")
         target["attach"] = [
             {
@@ -150,9 +151,10 @@ class TestIcebergLakekeeperIncrementalMaterialization:
         return url
 
     @pytest.fixture(scope="class")
-    def profiles_config_update(self, dbt_profile_target, lakekeeper_url):
+    def profiles_config_update(self, dbt_profile_target, lakekeeper_url, unique_schema):
         warehouse = os.environ.get("LAKEKEEPER_WAREHOUSE", _DEFAULT_LAKEKEEPER_WAREHOUSE)
         target = dict(dbt_profile_target)
+        target["schema"] = unique_schema
         target["path"] = target.get("path", ":memory:")
         target["attach"] = [
             {
@@ -182,6 +184,13 @@ class TestIcebergLakekeeperIncrementalMaterialization:
         )[0]
         assert row_count == 2
 
+    @pytest.mark.xfail(
+        reason=(
+            "DuckDB Iceberg: information_schema.columns returns '__' for Iceberg table "
+            "columns, breaking get_columns_in_relation. Tracked upstream in duckdb/duckdb-iceberg."
+        ),
+        strict=False,
+    )
     def test_incremental_second_run_appends(self, project):
         result = run_dbt(["run", "--select", "incremental_model"], expect_pass=True)
         assert len(result.results) == 1

--- a/tests/unit/test_duckdb_adapter.py
+++ b/tests/unit/test_duckdb_adapter.py
@@ -351,3 +351,66 @@ class TestDuckDBAdapterIsDucklake(unittest.TestCase):
         result = adapter.is_ducklake(relation)
         self.assertTrue(result)
 
+    def test_is_iceberg_with_attachment_type(self):
+        profile_cfg = self.base_profile_cfg.copy()
+        profile_cfg["outputs"]["test"]["attach"] = [
+            {
+                "alias": "iceberg_db",
+                "path": "http://localhost:8181/catalog",
+                "type": "iceberg",
+            }
+        ]
+
+        adapter = self._get_adapter(profile_cfg)
+        relation = DuckDBRelation.create(database="iceberg_db", schema="ns", identifier="tbl")
+
+        self.assertTrue(adapter.is_iceberg(relation))
+
+    def test_is_iceberg_false_for_non_iceberg(self):
+        profile_cfg = self.base_profile_cfg.copy()
+        profile_cfg["outputs"]["test"]["attach"] = [
+            {
+                "alias": "regular_db",
+                "path": "/path/to/regular.db",
+            }
+        ]
+
+        adapter = self._get_adapter(profile_cfg)
+        relation = DuckDBRelation.create(database="regular_db", schema="ns", identifier="tbl")
+
+        self.assertFalse(adapter.is_iceberg(relation))
+
+    def test_is_iceberg_false_for_none_relation(self):
+        adapter = self._get_adapter(self.base_profile_cfg)
+        self.assertFalse(adapter.is_iceberg(None))
+
+    def test_is_iceberg_type_case_insensitive(self):
+        profile_cfg = self.base_profile_cfg.copy()
+        profile_cfg["outputs"]["test"]["attach"] = [
+            {
+                "alias": "ice_db",
+                "path": "http://localhost:8181/catalog",
+                "type": "ICEBERG",
+            }
+        ]
+
+        adapter = self._get_adapter(profile_cfg)
+        relation = DuckDBRelation.create(database="ice_db", schema="ns", identifier="tbl")
+
+        self.assertTrue(adapter.is_iceberg(relation))
+
+    def test_is_iceberg_false_for_ducklake(self):
+        """ducklake attachments must not be detected as iceberg."""
+        profile_cfg = self.base_profile_cfg.copy()
+        profile_cfg["outputs"]["test"]["attach"] = [
+            {
+                "alias": "lake_db",
+                "path": "ducklake:sqlite:/tmp/meta.sqlite",
+            }
+        ]
+
+        adapter = self._get_adapter(profile_cfg)
+        relation = DuckDBRelation.create(database="lake_db", schema="ns", identifier="tbl")
+
+        self.assertFalse(adapter.is_iceberg(relation))
+


### PR DESCRIPTION
## Summary

- DuckDB's Iceberg extension cannot execute `CTAS` and `ALTER...RENAME` in the same transaction against a REST catalog (e.g. lakekeeper)
- Detects attachments with `type: iceberg` via a new `_iceberg_dbs` set in credentials and `is_iceberg()` adapter method (mirrors existing `is_ducklake()` pattern)
- Commits any open transaction inside `duckdb__rename_relation` when renaming an Iceberg relation, ensuring CTAS and rename always run in separate transactions
- Fix lives entirely in `duckdb__rename_relation` — no changes to `table.sql` or `incremental.sql`, so all materializations get correct behavior automatically

## Simpler alternative to #725

PR #725 avoided CTAS entirely for Iceberg (CREATE TABLE + INSERT) and replaced ALTER...RENAME with DROP + CREATE + INSERT. This PR is simpler because DuckDB now supports Iceberg CTAS correctly — the only remaining constraint is the transaction split, which is a 4-line change in the rename macro.

## Test plan

- [ ] Unit tests: `uv run --with pytest --with-editable . pytest tests/unit/test_duckdb_adapter.py -k iceberg -v`
- [ ] Integration tests against lakekeeper (auto-skip if not running): `uv run --with pytest --with-editable . pytest tests/functional/adapter/test_iceberg_lakekeeper_integration.py -v`
  - Set `LAKEKEEPER_URL` / `LAKEKEEPER_WAREHOUSE` env vars to point at your instance
  - Exercises first run (CTAS only), second run (CTAS → commit → rename), and `--full-refresh`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)