### PR TITLE
fix: skip target.schema prefix for attached Iceberg REST catalog databases

### DIFF
--- a/dbt/adapters/duckdb/credentials.py
+++ b/dbt/adapters/duckdb/credentials.py
@@ -245,6 +245,9 @@ class DuckDBCredentials(Credentials):
         if self.is_ducklake or "ducklake:" in self.path.lower():
             self._ducklake_dbs.add(self.path_derived_database_name(self.path))
 
+        # Build set of Iceberg REST catalog database names for schema name generation
+        self._iceberg_catalog_dbs: set = set()
+
         if self.attach:
             for attachment in self.attach:
                 is_ducklake_flag = getattr(attachment, "is_ducklake", None)
@@ -259,6 +262,17 @@ class DuckDBCredentials(Credentials):
                         self._ducklake_dbs.add(alias)
                     else:
                         self._ducklake_dbs.add(self.path_derived_database_name(path))
+
+                # Detect Iceberg REST catalog via .type field or options dict
+                attachment_type = None
+                if attachment.type:
+                    attachment_type = attachment.type.lower()
+                elif attachment.options and "type" in attachment.options:
+                    attachment_type = str(attachment.options["type"]).lower()
+
+                if attachment_type == "iceberg":
+                    name = alias or self.path_derived_database_name(path)
+                    self._iceberg_catalog_dbs.add(name)
 
         # Add MotherDuck plugin if the path is a MotherDuck database
         # and plugin was not specified in profile.yml

--- a/dbt/adapters/duckdb/impl.py
+++ b/dbt/adapters/duckdb/impl.py
@@ -160,6 +160,13 @@ class DuckDBAdapter(SQLAdapter):
         return relation.database in self.config.credentials._ducklake_dbs
 
     @available
+    def is_iceberg_catalog_db(self, database_name: Optional[str]) -> bool:
+        """Return True if database_name is an attached Iceberg REST catalog."""
+        if not database_name:
+            return False
+        return database_name in self.config.credentials._iceberg_catalog_dbs
+
+    @available
     def convert_datetimes_to_strs(self, table: "agate.Table") -> "agate.Table":
         import agate
 

--- a/dbt/include/duckdb/macros/adapters.sql
+++ b/dbt/include/duckdb/macros/adapters.sql
@@ -46,6 +46,20 @@
   {{ return(run_query(sql)) }}
 {% endmacro %}
 
+{% macro duckdb__generate_schema_name(custom_schema_name, node) -%}
+  {%- set default_schema = target.schema -%}
+  {%- if custom_schema_name is none -%}
+    {{ default_schema }}
+  {%- else -%}
+    {%- set node_db = node.config.database if (node is not none and node.config is not none) else none -%}
+    {%- if node_db is not none and adapter.is_iceberg_catalog_db(node_db) -%}
+      {{ custom_schema_name | trim }}
+    {%- else -%}
+      {{ default_schema }}_{{ custom_schema_name | trim }}
+    {%- endif -%}
+  {%- endif -%}
+{%- endmacro %}
+
 {% macro get_column_names() %}
   {# loop through user_provided_columns to get column names #}
     {%- set user_provided_columns = model['columns'] -%}

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -418,10 +418,64 @@ def test_add_secret_with_list():
             )
         ]
     )
-    
+
     sql = creds.secrets_sql()[0]
     expected = """CREATE OR REPLACE SECRET test_secret (
     type custom,
     allowed_hosts array ['host1', 'host2', 'host3']
 )"""
     assert sql == expected
+
+
+def test_iceberg_catalog_dbs_populated_via_options():
+    """Iceberg attach detected when type is in the options dict."""
+    creds = DuckDBCredentials(
+        attach=[
+            Attachment(
+                path="lakehouse",
+                alias="polaris",
+                options={"type": "iceberg", "endpoint": "http://polaris:8181/api/catalog"},
+            )
+        ]
+    )
+    assert "polaris" in creds._iceberg_catalog_dbs
+
+
+def test_iceberg_catalog_dbs_populated_via_type_field():
+    """Iceberg attach detected when type is the direct .type field."""
+    creds = DuckDBCredentials(
+        attach=[Attachment(path="lakehouse", alias="polaris", type="iceberg")]
+    )
+    assert "polaris" in creds._iceberg_catalog_dbs
+
+
+def test_iceberg_catalog_dbs_uses_path_when_no_alias():
+    """Falls back to path-derived name when attachment has no alias."""
+    creds = DuckDBCredentials(
+        attach=[Attachment(path="/tmp/catalog.duckdb", options={"type": "iceberg"})]
+    )
+    assert "catalog" in creds._iceberg_catalog_dbs
+
+
+def test_iceberg_catalog_dbs_empty_for_regular_attach():
+    """Regular DuckDB attach must not appear in _iceberg_catalog_dbs."""
+    creds = DuckDBCredentials(
+        attach=[Attachment(path="/tmp/other.duckdb", alias="other")]
+    )
+    assert len(creds._iceberg_catalog_dbs) == 0
+
+
+def test_iceberg_catalog_dbs_empty_for_sqlite_attach():
+    """SQLite attach must not appear in _iceberg_catalog_dbs."""
+    creds = DuckDBCredentials(
+        attach=[Attachment(path="/tmp/other.db", alias="other", type="sqlite")]
+    )
+    assert len(creds._iceberg_catalog_dbs) == 0
+
+
+def test_iceberg_catalog_dbs_type_case_insensitive():
+    """Type matching is case-insensitive (e.g., 'ICEBERG' or 'Iceberg')."""
+    creds = DuckDBCredentials(
+        attach=[Attachment(path="lh", alias="cat", options={"type": "ICEBERG"})]
+    )
+    assert "cat" in creds._iceberg_catalog_dbs

--- a/tests/unit/test_duckdb_adapter.py
+++ b/tests/unit/test_duckdb_adapter.py
@@ -77,6 +77,53 @@ class TestDuckDBAdapter(unittest.TestCase):
             alter.assert_not_called()
 
 
+class TestDuckDBAdapterIcebergCatalog(unittest.TestCase):
+    def _make_adapter(self, attach):
+        set_from_args(Namespace(STRICT_MODE=True), {})
+        profile_cfg = {
+            "outputs": {
+                "test": {
+                    "type": "duckdb",
+                    "path": ":memory:",
+                    "attach": attach,
+                }
+            },
+            "target": "test",
+        }
+        project_cfg = {
+            "name": "X",
+            "version": "0.1",
+            "profile": "test",
+            "project-root": "/tmp/dbt/does-not-exist",
+            "quoting": {"identifier": False, "schema": True},
+            "config-version": 2,
+        }
+        config = config_from_parts_or_dicts(project_cfg, profile_cfg, cli_vars={})
+        return DuckDBAdapter(config, mock.MagicMock())
+
+    def test_is_iceberg_catalog_db_true(self):
+        adapter = self._make_adapter(
+            [{"path": "lakehouse", "alias": "polaris", "options": {"type": "iceberg", "endpoint": "http://polaris:8181/api/catalog"}}]
+        )
+        assert adapter.is_iceberg_catalog_db("polaris") is True
+
+    def test_is_iceberg_catalog_db_false_for_regular_db(self):
+        adapter = self._make_adapter(
+            [{"path": "lakehouse", "alias": "polaris", "options": {"type": "iceberg", "endpoint": "http://polaris:8181/api/catalog"}}]
+        )
+        assert adapter.is_iceberg_catalog_db("main") is False
+
+    def test_is_iceberg_catalog_db_false_when_no_iceberg_attach(self):
+        adapter = self._make_adapter([{"path": "/tmp/other.duckdb", "alias": "other"}])
+        assert adapter.is_iceberg_catalog_db("other") is False
+
+    def test_is_iceberg_catalog_db_none(self):
+        adapter = self._make_adapter(
+            [{"path": "lakehouse", "alias": "polaris", "options": {"type": "iceberg", "endpoint": "http://polaris:8181/api/catalog"}}]
+        )
+        assert adapter.is_iceberg_catalog_db(None) is False
+
+
 class TestDuckDBAdapterWithSecrets(unittest.TestCase):
     def setUp(self):
         set_from_args(Namespace(STRICT_MODE=True), {})


### PR DESCRIPTION
## Problem

When targeting an attached Iceberg REST catalog, the default \`generate_schema_name\` macro prepends \`target.schema\` to any custom schema name, producing \`{target.schema}_{schema}\` instead of \`{schema}\`. For an attached Iceberg catalog the schema maps to an **Iceberg namespace** — a discrete catalog object — not a local DuckDB schema. The prefixed namespace does not exist in the catalog, causing runtime failures.

See #754 for a full reproduction with profile config, \`dbt_project.yml\`, and expected vs. actual resolved relations.

## Fix

Follow the existing DuckLake pattern (\`_ducklake_dbs\` / \`is_ducklake\`):

1. **\`credentials.py\`** — populate \`_iceberg_catalog_dbs\` from \`attach\` entries whose resolved type is \`\"iceberg\"\` (via \`.type\` field or \`options\` dict).
2. **\`impl.py\`** — expose \`is_iceberg_catalog_db(database_name: str) -> bool\` decorated \`@available\`.
3. **\`macros/adapters.sql\`** — add \`duckdb__generate_schema_name\` that returns \`custom_schema_name\` unchanged when the node's configured database is an Iceberg catalog attachment, and falls back to the standard \`{target.schema}_{custom_schema_name}\` behaviour otherwise.

Project-level \`generate_schema_name\` overrides dispatch before adapter macros, so existing projects with the current workaround are unaffected.

## Tests

- 6 unit tests in \`test_credentials.py\` — \`_iceberg_catalog_dbs\` population via options dict, via \`.type\` field, path fallback when no alias, non-iceberg attach, SQLite attach, case-insensitive type matching.
- 4 unit tests in \`test_duckdb_adapter.py\` — \`is_iceberg_catalog_db\` returns true for an iceberg attach, false for a regular db name, false when no iceberg attach is configured, false for \`None\`.

All 10 new tests pass. 101 pre-existing unit tests pass.