### PR TITLE
Use DESCRIBE for get_columns_in_relation to avoid full catalog load (closes #762)

### DIFF
--- a/dbt/adapters/duckdb/impl.py
+++ b/dbt/adapters/duckdb/impl.py
@@ -139,6 +139,16 @@ class DuckDBAdapter(SQLAdapter):
         # an unfiltered information_schema.columns scan triggers a full metastore load.
         return
 
+    def get_columns_in_relation(self, relation: BaseRelation) -> List[BaseColumn]:
+        # DESCRIBE (see issue #762) raises on a missing relation; preserve the old
+        # information_schema behavior of returning [] for callers that probe existence.
+        try:
+            return super().get_columns_in_relation(relation)
+        except DbtRuntimeError as e:
+            if "does not exist" in str(e).lower():
+                return []
+            raise
+
     @available
     def parse_index(self, raw_index: Any) -> Optional[DuckDBIndexConfig]:
         return DuckDBIndexConfig.parse(raw_index)

--- a/dbt/include/duckdb/macros/adapters.sql
+++ b/dbt/include/duckdb/macros/adapters.sql
@@ -257,24 +257,17 @@ def materialize(df, con):
 {% endmacro %}
 
 {% macro duckdb__get_columns_in_relation(relation) -%}
+  {# DESCRIBE avoids the global information_schema.columns scan, which forces a full
+     catalog load on attached catalogs like DuckLake (issue #762). DuckDB's column_type
+     carries precision/scale in the type string, so the null literals are safe. #}
   {% call statement('get_columns_in_relation', fetch_result=True) %}
       select
           column_name,
-          data_type,
-          character_maximum_length,
-          numeric_precision,
-          numeric_scale
-
-      from system.information_schema.columns
-      where table_name = '{{ relation.identifier }}'
-      {% if relation.schema %}
-      and lower(table_schema) = '{{ relation.schema | lower }}'
-      {% endif %}
-      {% if relation.database %}
-      and lower(table_catalog) = '{{ relation.database | lower }}'
-      {% endif %}
-      order by ordinal_position
-
+          column_type as data_type,
+          cast(null as bigint) as character_maximum_length,
+          cast(null as bigint) as numeric_precision,
+          cast(null as bigint) as numeric_scale
+      from (describe {{ relation.render() }})
   {% endcall %}
   {% set table = load_result('get_columns_in_relation').table %}
   {{ return(sql_convert_columns_in_relation(table)) }}

--- a/tests/functional/adapter/test_get_columns_in_relation.py
+++ b/tests/functional/adapter/test_get_columns_in_relation.py
@@ -1,0 +1,46 @@
+import pytest
+
+from dbt.tests.util import (
+    get_connection,
+    relation_from_name,
+    run_dbt,
+)
+
+# duckdb__get_columns_in_relation resolves columns via DESCRIBE (issue #762). Pin the
+# type-string fidelity (precision + nested types) and the missing-relation -> [] guard.
+
+types_model_sql = """
+{{ config(materialized='table') }}
+
+select
+    1::integer as id,
+    1.5::decimal(18, 2) as amount,
+    'x'::varchar as label,
+    cast(null as struct(fname varchar, age integer)) as nested
+"""
+
+
+class TestGetColumnsInRelation:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"types_model.sql": types_model_sql}
+
+    def test_describe_preserves_type_strings(self, project):
+        run_dbt(["run"])
+
+        relation = relation_from_name(project.adapter, "types_model")
+        with get_connection(project.adapter):
+            columns = project.adapter.get_columns_in_relation(relation)
+
+        dtypes = {c.name: c.dtype for c in columns}
+        assert dtypes["id"] == "INTEGER"
+        # Precision/scale are carried in the type string, not separate fields.
+        assert dtypes["amount"] == "DECIMAL(18,2)"
+        assert dtypes["label"] == "VARCHAR"
+        assert dtypes["nested"] == "STRUCT(fname VARCHAR, age INTEGER)"
+
+    def test_missing_relation_returns_empty_list(self, project):
+        relation = relation_from_name(project.adapter, "does_not_exist_xyz")
+        with get_connection(project.adapter):
+            columns = project.adapter.get_columns_in_relation(relation)
+        assert columns == []


### PR DESCRIPTION
## Problem

`duckdb__get_columns_in_relation` queries the global `system.information_schema.columns` view. That view spans **all** attached catalogs, so enumerating it forces a full catalog load for catalogs like DuckLake whose column metadata lives in an external metadata database. [#762](https://github.com/duckdb/dbt-duckdb/issues/762) reports this at **726s** for a single staging-table lookup during an incremental `merge`.

The reporter ([@chaegordon](https://github.com/chaegordon)) did the legwork here, including the non-obvious part: adding a `table_schema`/`table_catalog` predicate does **not** help. The first `information_schema.columns` hit on a cold connection materializes DuckLake's entire column catalog regardless of the filter — normal runs just pay that cost on the first (temp-table) lookup and the later filtered lookups only *look* fast because the catalog is already warm.

## Fix

Resolve columns via `DESCRIBE` instead. It looks the single relation up through the catalog search path and never triggers the global enumeration. Reporter confirmed the model drops from ~726s to **<15s** end to end.

DuckDB's `column_type` already carries any precision/scale/length in the type string (e.g. `DECIMAL(18,2)`), and I verified `DESCRIBE`'s `column_type` is byte-identical to `information_schema`'s `data_type` for `DECIMAL`, `VARCHAR`, `STRUCT`, nested structs, `MAP`, and lists — so the dropped `numeric_precision`/`numeric_scale`/`character_maximum_length` columns are safe to null out (DuckDB's `Column` never consulted them for these types anyway).

## Note for reviewers — the try/except

`DESCRIBE` raises a `CatalogException` for a missing relation, whereas the old `information_schema` query returned an empty list. The adapter override normalizes that back to `[]`.

This control-flow-via-exception looks a little off at first glance, but it's the **established pattern for `DESCRIBE`-based dbt adapters** — `dbt-spark`/`dbt-databricks` do the identical thing in their `get_columns_in_relation` (`impl.py`), with the comment *"spark would throw error when table doesn't exist, where other CDW would just return an empty list, normalizing the behavior here."* The alternatives are worse: a pre-check query reintroduces per-call metadata latency (the exact thing we're removing), and the in-memory relation cache isn't reliably populated for temp relations. The `[]` behavior is also relied on by dbt's shared `check_table_does_not_exist` test helper.

## Tests

Added `tests/functional/adapter/test_get_columns_in_relation.py` covering type-string fidelity (precision + nested struct) and the missing-relation → `[]` guard. Regression-ran the affected paths (incremental, external/struct-flatten, persist_docs, constraints, basic adapter-method + docs-generate): **63 passed, 4 skipped** (S3/DuckLake creds-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)