### PR TITLE
Expose attachment endpoints for OpenLineage lineage tracking with Iceberg catalogs

### DIFF
--- a/dbt/adapters/duckdb/impl.py
+++ b/dbt/adapters/duckdb/impl.py
@@ -219,6 +219,23 @@ class DuckDBAdapter(SQLAdapter):
         return DuckDBConnectionManager.env().get_binding_char()
 
     @available
+    def get_attachment_endpoints(self) -> Any:
+        """Return a mapping of attachment aliases to their endpoint URIs.
+
+        Enables OpenLineage and other external integrations to derive proper namespaces
+        for catalog lineage tracking. Each entry maps an attachment alias (or path)
+        to its configured endpoint.
+
+        Returns a dict where keys are attachment aliases (or paths) and values are endpoint URIs.
+        """
+        endpoints = {}
+        if self.config.credentials.attach:
+            for attachment in self.config.credentials.attach:
+                key = attachment.alias if attachment.alias else attachment.path
+                endpoints[key] = attachment.path
+        return endpoints
+
+    @available
     def external_write_options(self, write_location: str, rendered_options: dict) -> str:
         if "format" not in rendered_options:
             ext = os.path.splitext(write_location)[1].lower()

--- a/tests/unit/test_duckdb_adapter.py
+++ b/tests/unit/test_duckdb_adapter.py
@@ -351,3 +351,69 @@ class TestDuckDBAdapterIsDucklake(unittest.TestCase):
         result = adapter.is_ducklake(relation)
         self.assertTrue(result)
 
+
+class TestDuckDBAdapterGetAttachmentEndpoints(unittest.TestCase):
+    def setUp(self):
+        set_from_args(Namespace(STRICT_MODE=True), {})
+
+        self.base_profile_cfg = {
+            "outputs": {
+                "test": {
+                    "type": "duckdb",
+                    "path": ":memory:",
+                }
+            },
+            "target": "test",
+        }
+
+        project_cfg = {
+            "name": "X",
+            "version": "0.1",
+            "profile": "test",
+            "project-root": "/tmp/dbt/does-not-exist",
+            "quoting": {
+                "identifier": False,
+                "schema": True,
+            },
+            "config-version": 2,
+        }
+
+        self.project_cfg = project_cfg
+        self.mock_mp_context = mock.MagicMock()
+
+    def _get_adapter(self, profile_cfg):
+        config = config_from_parts_or_dicts(self.project_cfg, profile_cfg, cli_vars={})
+        return DuckDBAdapter(config, self.mock_mp_context)
+
+    def test_get_attachment_endpoints_no_attachments(self):
+        """Test get_attachment_endpoints returns empty dict when no attachments configured."""
+        adapter = self._get_adapter(self.base_profile_cfg)
+        result = adapter.get_attachment_endpoints()
+        self.assertEqual(result, {})
+
+    def test_get_attachment_endpoints_with_attachments(self):
+        """Test get_attachment_endpoints returns correct mapping for attachments."""
+        profile_cfg = self.base_profile_cfg.copy()
+        profile_cfg["outputs"]["test"]["attach"] = [
+            {"alias": "polaris", "path": "iceberg://http://polaris:8181/api/catalog"},
+            {"alias": "postgres_db", "path": "postgresql://user@localhost/database"},
+            {"path": "s3://bucket/db.duckdb"},
+        ]
+        adapter = self._get_adapter(profile_cfg)
+        result = adapter.get_attachment_endpoints()
+
+        self.assertEqual(result, {
+            "polaris": "iceberg://http://polaris:8181/api/catalog",
+            "postgres_db": "postgresql://user@localhost/database",
+            "s3://bucket/db.duckdb": "s3://bucket/db.duckdb",
+        })
+
+    def test_get_attachment_endpoints_without_alias_uses_path(self):
+        """Test get_attachment_endpoints uses path as key when alias is missing."""
+        profile_cfg = self.base_profile_cfg.copy()
+        profile_cfg["outputs"]["test"]["attach"] = [
+            {"path": "s3://bucket/db.duckdb"}
+        ]
+        adapter = self._get_adapter(profile_cfg)
+        result = adapter.get_attachment_endpoints()
+        self.assertEqual(result, {"s3://bucket/db.duckdb": "s3://bucket/db.duckdb"})


### PR DESCRIPTION
# Expose attachment endpoints for OpenLineage lineage tracking with Iceberg catalogs

## Problem
When using dbt-duckdb with ATTACH-based Iceberg catalogs (e.g., Apache Polaris), 
OpenLineage integrations incorrectly derive the dataset namespace from the local 
DuckDB file path (e.g., `duckdb:///tmp/db.duckdb`) instead of the attached catalog's 
endpoint URI (e.g., `http://polaris:8181/api/catalog`). This causes lineage edges to 
be silently dropped because the namespace doesn't match any registered catalog 
service in OpenMetadata.

Fixes #764

## Solution
Add a new `@available` method `get_attachment_endpoints()` to the DuckDBAdapter that 
exposes attachment endpoint URIs to external integrations like OpenLineage. This 
enables proper namespace derivation for datasets from attached catalogs.

## Implementation Details
- Added `get_attachment_endpoints()` method to `DuckDBAdapter` class (16 lines)
- Returns `Dict[str, str]` mapping attachment aliases to endpoint URIs
- Pure read-only function with no side effects or state mutations
- Only called when explicitly invoked by external integrations
- Fully backward compatible - returns empty dict if no attachments configured

## Changes
- `dbt/adapters/duckdb/impl.py` - Added 1 new method
- `tests/unit/test_duckdb_adapter.py` - Added 3 unit tests
- Total: +83 lines, -0 lines modified

## Testing
All tests passing:
- ✅ 3/3 new unit tests for `get_attachment_endpoints()`
- ✅ 19/19 existing adapter tests pass (including 11 DuckLake tests)

## Impact Analysis
- ✅ Zero breaking changes
- ✅ No modifications to existing code paths
- ✅ Purely additive patch
- ✅ Safe for DuckLake users (11 DuckLake tests pass unchanged)
- ✅ Safe for MotherDuck users (no connection changes)
- ✅ Safe for regular DuckDB users (no local DB changes)
- ✅ Only affects future OpenLineage integration implementations