### PR TITLE
Use full database.schema.index path in drop_indexes_on_relation (closes #771)

### DIFF
--- a/dbt/include/duckdb/macros/adapters.sql
+++ b/dbt/include/duckdb/macros/adapters.sql
@@ -398,7 +398,8 @@ def materialize(df, con):
   {% call statement('get_indexes_on_relation', fetch_result=True, auto_begin=False) %}
     SELECT index_name
     FROM duckdb_indexes()
-    WHERE schema_name = '{{ relation.schema }}'
+    WHERE database_name = '{{ relation.database }}'
+      AND schema_name = '{{ relation.schema }}'
       AND table_name = '{{ relation.identifier }}'
   {% endcall %}
 
@@ -406,7 +407,7 @@ def materialize(df, con):
   {% for row in results %}
     {% set index_name = row[0] %}
     {% call statement('drop_index_' + loop.index|string, auto_begin=false) %}
-      DROP INDEX "{{ relation.schema }}"."{{ index_name }}"
+      DROP INDEX "{{ relation.database }}"."{{ relation.schema }}"."{{ index_name }}"
     {% endcall %}
   {% endfor %}
 {%- endmacro %}

--- a/tests/functional/adapter/test_attach.py
+++ b/tests/functional/adapter/test_attach.py
@@ -87,3 +87,59 @@ class TestAttachedDatabase:
         # check that everything works on a re-run of dbt
         rerun_results = run_dbt()
         assert len(rerun_results) == 2
+
+
+indexed_model_sql = """
+    {{ config(
+        materialized='table',
+        database='attach_test',
+        indexes=[{'columns': ['id']}],
+    ) }}
+    SELECT 1 as id
+"""
+
+
+@pytest.mark.skip_profile("memory", "buenavista", "md")
+class TestIndexOnAttachedDatabase:
+    """Regression test for #771: dropping indexes on a table in an attached
+    (non-default) catalog requires the full three-part database.schema.index
+    path. The second dbt run exercises the DROP INDEX path in
+    drop_indexes_on_relation."""
+
+    @pytest.fixture(scope="class")
+    def attach_test_db(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = os.path.join(temp_dir, "attach_test.duckdb")
+            db = duckdb.connect(path)
+            db.close()
+            yield path
+
+    @pytest.fixture(scope="class")
+    def profiles_config_update(self, dbt_profile_target, attach_test_db):
+        return {
+            "test": {
+                "outputs": {
+                    "dev": {
+                        "type": "duckdb",
+                        "path": dbt_profile_target.get("path", ":memory:"),
+                        "attach": [{"path": attach_test_db}],
+                    }
+                },
+                "target": "dev",
+            }
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"indexed_model.sql": indexed_model_sql}
+
+    def test_index_on_attached_database(self, project):
+        # First run creates the table + index (no DROP INDEX path).
+        results = run_dbt()
+        assert len(results) == 1
+
+        # Second run re-materializes the table, which drops the existing
+        # index first. Without the database_name prefix this fails with
+        # "Catalog Error: Index ... does not exist!".
+        rerun_results = run_dbt()
+        assert len(rerun_results) == 1


### PR DESCRIPTION
## Problem

`drop_indexes_on_relation` issued `DROP INDEX "{schema}"."{index_name}"`, a two-part path. For a model materialized into an **attached, non-default catalog** (e.g. `ATTACH ... TYPE postgres`), DuckDB requires the full three-part `database.schema.index` path, so the second `dbt run` of an indexed model fails:

```
Catalog Error: Index with name b7c448d... does not exist!
Did you mean "pg_gold.main_gold.b7c448d..."?
```

Reported in #771.

## Fix

Use the relation's own `database` field for both the `DROP INDEX` path and the `duckdb_indexes()` lookup:

- The `DROP INDEX` now uses the full three-part `database.schema.index` path.
- The lookup query is scoped by `database_name = relation.database`, so we don't match an index on a same-named table in a different attached catalog.

`relation.database` is derived the same way DuckDB names the catalog (file stem, `memory`, or attach alias via `path_derived_database_name`), so this is correct for the default catalog too — no dependence on reading the name back from the catalog.

## Testing

- Added `TestIndexOnAttachedDatabase` in `tests/functional/adapter/test_attach.py`, which materializes an indexed model into an attached DuckDB catalog and runs `dbt` twice (the second run exercises the DROP INDEX path). Verified it **fails on `master`** and **passes with this fix**.
- `tests/functional/adapter/indexes/test_indexes.py` still passes on both the default `memory` profile and the `file` profile, and `test_attach.py` passes on the `file` profile — confirming `relation.database` matches the catalog name DuckDB reports in the default, file, and attached cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)