### PR TITLE
Bound microbatch tests to their data windows (cut ~30 min off MotherDuck CI)

### DIFF
--- a/tests/functional/adapter/test_incremental_microbatch.py
+++ b/tests/functional/adapter/test_incremental_microbatch.py
@@ -387,11 +387,20 @@ class TestMicrobatchScenarios:
         assert count[0] == 5
 
     def test_microbatch_supports_hour_batch_size(self, project):
+        # All data lives in the first three hours of 2025-01-01, so bound the
+        # run to a 3-hour window. The default day-granularity bounds
+        # (2025-01-01..2025-01-04) would fan out into 72 hourly batches per
+        # run for no added coverage -- a needless cost, especially on
+        # MotherDuck where every batch is a network round-trip.
+        hour_start = "2025-01-01 00:00:00"
+        hour_end = "2025-01-01 03:00:00"
         self._run_with_bounds(
             "microbatch_batch_hour_input microbatch_batch_hour",
             project,
             expect_pass=True,
             full_refresh=True,
+            start=hour_start,
+            end=hour_end,
         )
 
         relation = relation_from_name(project.adapter, "microbatch_batch_hour")
@@ -407,7 +416,13 @@ class TestMicrobatchScenarios:
             "(5, '2025-01-01 00:45:00'::timestamp)"
         )
 
-        self._run_with_bounds("microbatch_batch_hour", project, expect_pass=True)
+        self._run_with_bounds(
+            "microbatch_batch_hour",
+            project,
+            expect_pass=True,
+            start=hour_start,
+            end=hour_end,
+        )
         count = project.run_sql(
             f"SELECT COUNT(*) as count FROM {relation}", fetch="one"
         )

--- a/tests/functional/adapter/test_incremental_microbatch.py
+++ b/tests/functional/adapter/test_incremental_microbatch.py
@@ -264,8 +264,26 @@ class TestMicrobatchUniqueKeyNotSupported:
         }
 
     def test_unique_key_not_supported(self, project, capsys):
+        # Bound the run to two daily batches. The model config has a fixed
+        # begin='2025-01-01' and no end, so without explicit event-time bounds
+        # dbt expands the microbatch into one daily batch per day from that
+        # date to "now" -- a count that grows every day and, since each batch
+        # spins up a relation, made this test progressively slower (notably on
+        # MotherDuck, where every batch is a network round-trip). The
+        # unique_key rejection only fires on the incremental path, so we need
+        # the first batch to create the table and the second to trigger the
+        # error: a two-day window exercises the same validation with exactly
+        # two batches.
         run_dbt(
-            ["run", "--select", "microbatch_unique_key_not_supported"],
+            [
+                "run",
+                "--select",
+                "microbatch_unique_key_not_supported",
+                "--event-time-start",
+                "2025-01-01",
+                "--event-time-end",
+                "2025-01-03",
+            ],
             expect_pass=False,
         )
         captured = capsys.readouterr()


### PR DESCRIPTION
## Problem

Two tests in `test_incremental_microbatch.py` ran `dbt run` over time windows far wider than their data, fanning out into hundreds of microbatches. On MotherDuck each batch is a network round-trip, so together they were ~30 of the ~62 minutes of the **MotherDuck functional test** CI job.

**1. `test_unique_key_not_supported` (~20 min, and growing daily).** The model that verifies the `unique_key` rejection has a fixed `begin='2025-01-01'` and no event-time end, and the test passed **no `--event-time-start/--event-time-end`**. So dbt expanded it into **one daily batch per day from 2025-01-01 to "now"** — 553 batches as of this PR, one more every day. The `unique_key` rejection only fires on the incremental path, so the run walked hundreds of batches before failing.

**2. `test_microbatch_supports_hour_batch_size` (~9 min).** All of its data lives in the first three hours of 2025-01-01, but it used the default day-granularity bounds (`2025-01-01..2025-01-04`) at hourly `batch_size` → **72 batches per run, 144 across its two runs**, for no added coverage.

## Fix

Bound each run to the window its data actually occupies:

- **`test_unique_key_not_supported`** → a **two-day window** (`2025-01-01..2025-01-03`). Two batches are needed, not one: batch 1 creates the table (`create table as` path — no error), batch 2 hits the incremental path and raises the expected error. Constant over time.
- **`test_microbatch_supports_hour_batch_size`** → a **3-hour window** (`00:00..03:00`), so 3 batches per run instead of 72.

Assertions are unchanged in both. Locally the full `test_incremental_microbatch` module still passes (13 tests) and the two tests drop from hundreds of batches to 2 and 3 respectively.

## Context

Found while investigating why the MotherDuck CI job on #772 took over an hour. Two things stacked up: these unbounded/over-wide batch windows, and the job's global serialization concurrency group (queueing behind other MD runs). This PR addresses the batch fan-out; the serialization is a separate, deliberate tradeoff (the tests share the single `md:test` catalog).

🤖 Generated with [Claude Code](https://claude.com/claude-code)