### PR TITLE
feat(gsheet): support service-account domain-wide delegation

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,22 @@ modules may be initialized using an arbitrary set of key-value pairs that are de
 `config` dictionary. In this example, we initialize the `gsheet` plugin with the setting `method: oauth` and we
 initialize the `sqlalchemy` plugin (aliased as "sql") with a `connection_url` that is set via an environment variable.
 
+The `gsheet` plugin also accepts the following optional config keys when `method: service`:
+
+* `keyfile` — path to the service-account JSON key (defaults to gspread's `~/.config/gspread/service_account.json`).
+* `impersonate` — a Google Workspace user's email to impersonate via [domain-wide delegation](https://developers.google.com/identity/protocols/oauth2/service-account#delegatingauthority), so the service account can read sheets on that user's behalf without sharing each file with the service account. Requires DWD to be enabled for the service account's client id in the Workspace admin console.
+* `scopes` — the OAuth scopes granted to the impersonated credentials (defaults to read-only sheets + drive).
+
+```yaml
+      plugins:
+        - module: gsheet
+          config:
+            method: service
+            impersonate: analyst@your-workspace.com
+            scopes:
+              - https://www.googleapis.com/auth/drive.readonly
+```
+
 Please remember that using plugins may require you to add additional dependencies to the Python environment that your dbt-duckdb pipeline runs in:
 
 * `excel` depends on `pandas`, and `openpyxl` or `xlsxwriter` to perform writes

--- a/dbt/adapters/duckdb/plugins/gsheet.py
+++ b/dbt/adapters/duckdb/plugins/gsheet.py
@@ -1,7 +1,10 @@
+import os
 from dataclasses import dataclass
 from typing import Any
 from typing import Dict
+from typing import List
 from typing import Literal
+from typing import Optional
 
 import gspread
 import pandas as pd
@@ -10,16 +13,38 @@ from . import BasePlugin
 from . import PluginConfig
 from ..utils import SourceConfig
 
+DEFAULT_IMPERSONATE_SCOPES = [
+    "https://www.googleapis.com/auth/spreadsheets.readonly",
+    "https://www.googleapis.com/auth/drive.readonly",
+]
+
 
 @dataclass
 class GSheetConfig(PluginConfig):
     method: Literal["service", "oauth"]
+    keyfile: Optional[str] = None
+    impersonate: Optional[str] = None
+    scopes: Optional[List[str]] = None
 
     def client(self):
-        if self.method == "service":
-            return gspread.service_account()
-        else:
+        if self.method == "oauth":
             return gspread.oauth()
+
+        if self.impersonate:
+            from google.oauth2.service_account import Credentials
+
+            keyfile = os.path.expanduser(
+                self.keyfile or gspread.auth.DEFAULT_SERVICE_ACCOUNT_FILENAME
+            )
+            scopes = self.scopes or DEFAULT_IMPERSONATE_SCOPES
+            creds = Credentials.from_service_account_file(keyfile, scopes=scopes).with_subject(
+                self.impersonate
+            )
+            return gspread.authorize(creds)
+
+        if self.keyfile:
+            return gspread.service_account(filename=os.path.expanduser(self.keyfile))
+        return gspread.service_account()
 
 
 class Plugin(BasePlugin):

--- a/tests/functional/plugins/test_gsheet.py
+++ b/tests/functional/plugins/test_gsheet.py
@@ -83,3 +83,29 @@ class TestGSheetPlugin:
                 "source_model2",
             ],
         )
+
+
+def test_gsheet_config_service_impersonate_parsing():
+    from dbt.adapters.duckdb.plugins.gsheet import GSheetConfig
+
+    cfg = GSheetConfig.from_dict(
+        {
+            "method": "service",
+            "keyfile": "/tmp/sa.json",
+            "impersonate": "analyst@example.com",
+            "scopes": ["https://www.googleapis.com/auth/drive.readonly"],
+        }
+    )
+    assert cfg.method == "service"
+    assert cfg.keyfile == "/tmp/sa.json"
+    assert cfg.impersonate == "analyst@example.com"
+    assert cfg.scopes == ["https://www.googleapis.com/auth/drive.readonly"]
+
+
+def test_gsheet_config_defaults():
+    from dbt.adapters.duckdb.plugins.gsheet import GSheetConfig
+
+    cfg = GSheetConfig.from_dict({"method": "oauth"})
+    assert cfg.keyfile is None
+    assert cfg.impersonate is None
+    assert cfg.scopes is None


### PR DESCRIPTION
Add optional config keys to the built-in gsheet plugin (method=service):
- impersonate: a Workspace user email to impersonate via domain-wide delegation, so the service account reads sheets on their behalf without sharing each file
- keyfile: path to the service-account JSON (defaults to gspread's default)
- scopes: OAuth scopes for the impersonated credentials (defaults read-only)

Backwards compatible: all new keys are optional; existing method=service/oauth behaviour is unchanged. Adds README docs and config-parsing tests.