### PR TITLE
Revert "Bump pyarrow from 24.0.0 to 25.0.0"

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -14,7 +14,7 @@ dbt-tests-adapter==1.20.0
 boto3
 mypy-boto3-glue
 pandas
-pyarrow==25.0.0
+pyarrow==24.0.0
 buenavista==0.5.0
 bumpversion
 flaky


### PR DESCRIPTION
Reverts #781 because the MotherDuck functional test began segfaulting after the upgrade to pyarrow 25.0.0. The same test suite passed with pyarrow 24.0.0; pin 24.0.0 until a patched 25.x release is available and validated.