### PR TITLE
fix: add missing return in GSheet plugin load() for range without headers

### DIFF
--- a/dbt/adapters/duckdb/plugins/gsheet.py
+++ b/dbt/adapters/duckdb/plugins/gsheet.py
@@ -90,8 +90,7 @@ class Plugin(BasePlugin):
                         f"Number of configured headers ({len(headers)}) does not match number of columns in fetched range ({len(df.columns)})."
                     )
             else:
-                df.rename(columns=df.iloc[0]).drop(df.index[0]).reset_index(drop=True)
-                return df
+                return df.rename(columns=df.iloc[0]).drop(df.index[0]).reset_index(drop=True)
 
         else:
             return pd.DataFrame(sheet.get_all_records())


### PR DESCRIPTION
When loading a GSheet range without headers, the `load()` method creates a new DataFrame via `df.rename().drop().reset_index()` but never returns it. The function falls through to return the original unmodified `df`, silently discarding the header rename and row drop. Added the missing `return` keyword.