### PR TITLE
fix: add missing @classmethod decorator to is_cancelable methods

### DIFF
--- a/dbt/adapters/duckdb/environments/buenavista.py
+++ b/dbt/adapters/duckdb/environments/buenavista.py
@@ -32,6 +32,7 @@ class BVEnvironment(Environment):
         cursor.close()
         return conn
 
+    @classmethod
     def is_cancelable(cls):
         return False
 

--- a/dbt/adapters/duckdb/environments/local.py
+++ b/dbt/adapters/duckdb/environments/local.py
@@ -64,6 +64,7 @@ class LocalEnvironment(Environment):
             if self.handle_count == 0 and not self._keep_open:
                 self.close()
 
+    @classmethod
     def is_cancelable(cls):
         return True
 


### PR DESCRIPTION
`LocalEnvironment.is_cancelable()` and `BuenaVistaEnvironment.is_cancelable()` use `cls` as the first parameter but lack the `@classmethod` decorator. The parent `Environment` ABC declares `is_cancelable` as a `@classmethod`, so the subclass overrides should match.