### PR TITLE
Fix README version info, MotherDuck compat, and repo URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This project is hosted on PyPI, so you should be able to install it and the nece
 
 `pip3 install dbt-duckdb`
 
-The latest supported version targets `dbt-core` versions >= 1.8.x and `duckdb` version 1.1.x, but we work hard to ensure that newer
+The latest supported version targets `dbt-core` versions >= 1.8.x and `duckdb` version >= 1.0.0, but we work hard to ensure that newer
 versions of DuckDB will continue to work with the adapter as they are released.
 
 ### Configuring Your Profile
@@ -50,7 +50,7 @@ or the Python API.
 
 MotherDuck databases generally work the same way as local DuckDB databases from the perspective of dbt, but
 there are a [few differences to be aware of](https://motherduck.com/docs/architecture-and-capabilities#considerations-and-limitations):
-1. MotherDuck is compatible with client DuckDB versions 0.10.2 and older.
+1. MotherDuck is compatible with client DuckDB versions 0.10.2 and newer.
 1. MotherDuck preloads a set of the most common DuckDB extensions for you, but does not support loading custom extensions or user-defined functions.
 
 As of `dbt-duckdb` 1.9.6, you can also connect to a DuckDB instance running [hosted DuckLake on MotherDuck](https://motherduck.com/blog/ducklake-motherduck/) by creating a DuckLake on MotherDuck and then setting `is_ducklake: true` in your `profiles.yml`.
@@ -446,7 +446,7 @@ to parse the source in a dbt model. The `formatter` configuration option for the
 we should use `newstyle` string formatting (the default), `oldstyle` string formatting, or `template` string
 formatting. You can read up on the strategies the various string formatting techniques use at this
 [Stack Overflow answer](https://stackoverflow.com/questions/13451989/pythons-many-ways-of-string-formatting-are-the-older-ones-going-to-be-depre) and see examples of their use
-in this [dbt-duckdb integration test](https://github.com/jwills/dbt-duckdb/blob/master/tests/functional/adapter/test_sources.py).
+in this [dbt-duckdb integration test](https://github.com/duckdb/dbt-duckdb/blob/master/tests/functional/adapter/test_sources.py).
 
 #### Writing to external files
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 name = dbt-duckdb
 author = Josh Wills
 author_email = joshwills+dbt@gmail.com
-url = https://github.com/jwills/dbt-duckdb
+url = https://github.com/duckdb/dbt-duckdb
 summary = The duckdb adapter plugin for dbt (data build tool)
 description_file = README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
## Summary

- **DuckDB version**: README claimed `duckdb version 1.1.x` but `setup.cfg` specifies `duckdb>=1.0.0`. Updated README to say `>= 1.0.0` to match the actual install requirement.
- **MotherDuck compatibility**: Fixed "0.10.2 and older" to "0.10.2 and newer" — MotherDuck supports DuckDB 0.10.2+, not 0.10.2 and below.
- **Repository URLs**: Updated remaining `jwills/dbt-duckdb` links to `duckdb/dbt-duckdb` in both README.md and `setup.cfg` to reflect the current repo location.

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Confirm `setup.cfg` url resolves to the correct repository