### PR TITLE
Fix SQL injection in CREATE SECRET via unescaped single quotes

### DIFF
--- a/dbt/adapters/duckdb/secrets.py
+++ b/dbt/adapters/duckdb/secrets.py
@@ -10,6 +10,35 @@ from dbt_common.dataclass_schema import dbtClassMixin
 
 DEFAULT_SECRET_PREFIX = "_dbt_secret_"
 
+# Characters allowed in a DuckDB SQL identifier (unquoted).
+# Used to validate secret names against injection.
+_VALID_IDENTIFIER_RE = None
+
+
+def _escape_sql_string(value: str) -> str:
+    """Escape single quotes in a SQL string literal by doubling them."""
+    return str(value).replace("'", "''")
+
+
+def _validate_identifier(name: str) -> str:
+    """Validate that *name* is a safe SQL identifier.
+
+    Raises ValueError if the name contains characters that could allow
+    SQL injection (semicolons, quotes, comments, etc.).
+    """
+    import re
+
+    global _VALID_IDENTIFIER_RE
+    if _VALID_IDENTIFIER_RE is None:
+        _VALID_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+    if not _VALID_IDENTIFIER_RE.match(name):
+        raise ValueError(
+            f"Invalid secret name {name!r}: must be a simple SQL identifier "
+            "(letters, digits, underscores; must start with a letter or underscore)."
+        )
+    return name
+
 
 @dataclass
 class Secret(dbtClassMixin):
@@ -47,19 +76,22 @@ class Secret(dbtClassMixin):
 
         if isinstance(value, dict):
             # Format as DuckDB map: map {'key1': 'value1', 'key2': 'value2'}
-            items = [f"'{k}': '{v}'" for k, v in value.items()]
+            items = [
+                f"'{_escape_sql_string(k)}': '{_escape_sql_string(v)}'"
+                for k, v in value.items()
+            ]
             return f"{key} map {{{', '.join(items)}}}"
         elif isinstance(value, list):
             # Format as DuckDB array: array ['item1', 'item2']
-            items = [f"'{item}'" for item in value]
+            items = [f"'{_escape_sql_string(item)}'" for item in value]
             return f"{key} array [{', '.join(items)}]"
         elif key in unquoted_keys:
             return f"{key} {value}"
         else:
-            return f"{key} '{value}'"
+            return f"{key} '{_escape_sql_string(value)}'"
 
     def to_sql(self) -> str:
-        name = f" {self.name}" if self.name else ""
+        name = f" {_validate_identifier(self.name)}" if self.name else ""
         or_replace = " OR REPLACE" if name else ""
         persistent = " PERSISTENT" if self.persistent is True else ""
         tab = "    "
@@ -80,7 +112,7 @@ class Secret(dbtClassMixin):
                 if value is not None and key not in ["name", "persistent"]:
                     params_sql.append(self._format_value(key, value))
             for s in scope_value:
-                params_sql.append(f"scope '{s}'")
+                params_sql.append(f"scope '{_escape_sql_string(s)}'")
 
             params_sql_str = f",\n{tab}".join(params_sql)
         else:

--- a/tests/unit/test_secrets.py
+++ b/tests/unit/test_secrets.py
@@ -1,0 +1,90 @@
+"""Tests for SQL-injection hardening in Secret.to_sql()."""
+
+import pytest
+
+from dbt.adapters.duckdb.secrets import Secret
+
+
+def _make_secret(**kwargs):
+    defaults = {"type": "s3"}
+    defaults.update(kwargs)
+    secret_type = defaults.pop("type")
+    name = defaults.pop("name", None)
+    provider = defaults.pop("provider", None)
+    scope = defaults.pop("scope", None)
+    persistent = defaults.pop("persistent", None)
+    return Secret.create(
+        secret_type=secret_type,
+        name=name,
+        provider=provider,
+        scope=scope,
+        persistent=persistent,
+        **defaults,
+    )
+
+
+class TestEscapeStringValues:
+    def test_plain_value_unchanged(self):
+        s = _make_secret(key_id="AKIAEXAMPLE")
+        sql = s.to_sql()
+        assert "key_id 'AKIAEXAMPLE'" in sql
+
+    def test_single_quote_in_value_is_escaped(self):
+        s = _make_secret(key_id="it's")
+        sql = s.to_sql()
+        assert "key_id 'it''s'" in sql
+
+    def test_multiple_quotes_escaped(self):
+        s = _make_secret(key_id="a'b'c")
+        sql = s.to_sql()
+        assert "key_id 'a''b''c'" in sql
+
+    def test_injection_payload_neutralized(self):
+        payload = "'); DROP TABLE secrets; --"
+        s = _make_secret(key_id=payload)
+        sql = s.to_sql()
+        # The payload must appear fully inside a quoted string, not break out
+        assert "DROP TABLE" in sql  # still present as data
+        assert "key_id '''); DROP TABLE secrets; --'" in sql
+
+
+class TestEscapeMapValues:
+    def test_map_value_with_quote(self):
+        s = _make_secret(extra_http_headers={"X-Key": "val'ue"})
+        sql = s.to_sql()
+        assert "'val''ue'" in sql
+
+    def test_map_key_with_quote(self):
+        s = _make_secret(extra_http_headers={"X-K'ey": "value"})
+        sql = s.to_sql()
+        assert "'X-K''ey'" in sql
+
+
+class TestEscapeListValues:
+    def test_list_item_with_quote(self):
+        s = _make_secret(scope=["s3://bucket/it's"])
+        sql = s.to_sql()
+        assert "'s3://bucket/it''s'" in sql
+
+
+class TestSecretNameValidation:
+    def test_valid_name(self):
+        s = _make_secret(name="my_secret_1")
+        sql = s.to_sql()
+        assert "SECRET my_secret_1" in sql
+
+    def test_name_with_injection_raises(self):
+        s = _make_secret(name="x; DROP TABLE t; --")
+        with pytest.raises(ValueError, match="Invalid secret name"):
+            s.to_sql()
+
+    def test_name_with_quote_raises(self):
+        s = _make_secret(name="secret'name")
+        with pytest.raises(ValueError, match="Invalid secret name"):
+            s.to_sql()
+
+    def test_no_name_is_fine(self):
+        s = _make_secret()
+        sql = s.to_sql()
+        assert "CREATE SECRET" in sql
+        assert "OR REPLACE" not in sql


### PR DESCRIPTION
## Summary

`Secret._format_value()` builds SQL fragments for `CREATE SECRET` statements by interpolating values inside single-quoted strings, but never escapes embedded single quotes. A secret value such as `it's` or a crafted payload like `'); DROP TABLE secrets; --` produces malformed SQL or enables injection into the generated `CREATE SECRET` statement.

This PR fixes the vulnerability by:

- **Escaping string literals**: all string values, map keys/values, list items, and scope values now have single quotes doubled (`'` -> `''`) before interpolation, which is standard SQL escaping
- **Validating secret names**: `to_sql()` now validates the secret name against a strict identifier pattern (`^[A-Za-z_][A-Za-z0-9_]*$`), raising `ValueError` for names containing injection characters (semicolons, quotes, spaces, etc.)

## Changes

- `dbt/adapters/duckdb/secrets.py`: Added `_escape_sql_string()` helper and `_validate_identifier()` validator; applied escaping in `_format_value()` for string, dict, and list branches; applied escaping to scope values and validation to secret name in `to_sql()`
- `tests/unit/test_secrets.py`: New test file with 11 tests covering plain values, single-quote escaping, injection payload neutralization, map/list escaping, name validation, and the no-name case

## Test plan

- [x] All 11 new unit tests pass (`pytest tests/unit/test_secrets.py`)
- [x] Existing unit tests unaffected
- [ ] Verify no downstream breakage in projects using secrets with normal (quote-free) values