### PR TITLE
Fix SQL injection in Attachment.to_sql()

### DIFF
--- a/dbt/adapters/duckdb/credentials.py
+++ b/dbt/adapters/duckdb/credentials.py
@@ -43,13 +43,23 @@ class Attachment(dbtClassMixin):
     # which is the case in fully managed ducklake in MotherDuck.
     is_ducklake: Optional[bool] = None
 
+    @staticmethod
+    def _escape_sql_string(value: str) -> str:
+        """Escape single quotes for use inside a SQL single-quoted string literal."""
+        return value.replace("'", "''")
+
+    @staticmethod
+    def _quote_identifier(name: str) -> str:
+        """Quote a DuckDB identifier with double quotes, escaping embedded double quotes."""
+        return '"' + name.replace('"', '""') + '"'
+
     def to_sql(self) -> str:
         # remove query parameters (not supported in ATTACH)
         parsed = urlparse(self.path)
         path = self.path.replace(f"?{parsed.query}", "")
-        base = f"ATTACH IF NOT EXISTS '{path}'"
+        base = f"ATTACH IF NOT EXISTS '{self._escape_sql_string(path)}'"
         if self.alias:
-            base += f" AS {self.alias}"
+            base += f" AS {self._quote_identifier(self.alias)}"
 
         # Check for conflicts between legacy fields and options dict
         if self.options:
@@ -107,7 +117,9 @@ class Attachment(dbtClassMixin):
                         ):
                             all_options.append(f"{key.upper()} {value}")
                         else:
-                            all_options.append(f"{key.upper()} '{value}'")
+                            all_options.append(
+                                f"{key.upper()} '{self._escape_sql_string(value)}'"
+                            )
                     else:
                         all_options.append(f"{key.upper()} {value}")
 

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -226,10 +226,10 @@ def test_attachments():
 
     expected_sql = [
         "ATTACH IF NOT EXISTS '/tmp/f1234.db'",
-        "ATTACH IF NOT EXISTS '/tmp/g1234.db' AS g",
+        'ATTACH IF NOT EXISTS \'/tmp/g1234.db\' AS "g"',
         "ATTACH IF NOT EXISTS '/tmp/h5678.db' (READ_ONLY)",
         "ATTACH IF NOT EXISTS '/tmp/i9101.db' (TYPE sqlite)",
-        "ATTACH IF NOT EXISTS '/tmp/jklm.db' AS jk (TYPE sqlite, READ_ONLY)",
+        'ATTACH IF NOT EXISTS \'/tmp/jklm.db\' AS "jk" (TYPE sqlite, READ_ONLY)',
     ]
 
     for i, a in enumerate(creds.attach):
@@ -250,7 +250,7 @@ def test_attachments_with_options():
         }
     )
     sql = attachment.to_sql()
-    assert "ATTACH IF NOT EXISTS '/tmp/test.db' AS test_db (CACHE_SIZE '1GB', THREADS 4, ENABLE_FSST)" == sql
+    assert 'ATTACH IF NOT EXISTS \'/tmp/test.db\' AS "test_db" (CACHE_SIZE \'1GB\', THREADS 4, ENABLE_FSST)' == sql
 
     # Test options dict with legacy options (no conflicts)
     attachment = Attachment(
@@ -425,3 +425,38 @@ def test_add_secret_with_list():
     allowed_hosts array ['host1', 'host2', 'host3']
 )"""
     assert sql == expected
+
+
+class TestAttachmentSQLInjection:
+    """Verify that user-supplied values are escaped to prevent SQL injection."""
+
+    def test_path_single_quote_escaped(self):
+        attachment = Attachment(path="/tmp/it's.db")
+        sql = attachment.to_sql()
+        assert "ATTACH IF NOT EXISTS '/tmp/it''s.db'" == sql
+
+    def test_path_injection_via_single_quote(self):
+        attachment = Attachment(path="'; DROP TABLE students; --")
+        sql = attachment.to_sql()
+        # The quote must be doubled, not left bare
+        assert "'';" in sql
+        assert "ATTACH IF NOT EXISTS '''; DROP TABLE students; --'" == sql
+
+    def test_alias_quoted_as_identifier(self):
+        attachment = Attachment(path="/tmp/test.db", alias="my_alias")
+        sql = attachment.to_sql()
+        assert 'AS "my_alias"' in sql
+
+    def test_alias_injection_via_double_quote(self):
+        attachment = Attachment(path="/tmp/test.db", alias='x"; DROP TABLE t; --')
+        sql = attachment.to_sql()
+        # Embedded double quote must be doubled inside the identifier
+        assert 'AS "x""; DROP TABLE t; --"' in sql
+
+    def test_option_string_value_escaped(self):
+        attachment = Attachment(
+            path="/tmp/test.db",
+            options={"data_path": "s3://bucket/it's-here"},
+        )
+        sql = attachment.to_sql()
+        assert "DATA_PATH 's3://bucket/it''s-here'" in sql


### PR DESCRIPTION
## Summary

`Attachment.to_sql()` in `dbt/adapters/duckdb/credentials.py` interpolates user-supplied values directly into `ATTACH` SQL statements without escaping, creating a SQL injection vector through crafted dbt profile configuration.

**Affected surfaces:**
- `self.path` — single-quoted but unescaped; a value containing `'` breaks out of the string literal
- `self.alias` — interpolated bare (unquoted); arbitrary SQL can be appended
- Option string values — single-quoted but unescaped, same issue as path

**Fix:**
- Escape single quotes in `path` and option string values by replacing `'` with `''` (standard SQL escaping)
- Quote `alias` as a DuckDB identifier using double quotes, with embedded `"` escaped to `""`
- Add helper methods `_escape_sql_string()` and `_quote_identifier()` on the `Attachment` class

## Test plan

- [x] Added `TestAttachmentSQLInjection` class with 5 tests covering injection via path, alias, and option values
- [x] Updated existing test expectations for the new alias quoting behavior
- [x] All 34 unit tests pass (`test_credentials.py` + `test_data_path_quoting.py`)