### PR TITLE
fix: sanitize SQL identifiers and values to prevent injection

### DIFF
--- a/dbt/adapters/duckdb/environments/__init__.py
+++ b/dbt/adapters/duckdb/environments/__init__.py
@@ -222,8 +222,11 @@ class Environment(abc.ABC):
         if creds.settings is not None:
             for key, value in creds.settings.items():
                 # Okay to set these as strings because DuckDB will cast them
-                # to the correct type
-                cursor.execute(f"SET {key} = '{value}'")
+                # to the correct type.
+                # Sanitize: quote key as identifier, escape single quotes in value.
+                safe_key = '"' + key.replace('"', '""') + '"'
+                safe_value = str(value).replace("'", "''")
+                cursor.execute(f"SET {safe_key} = '{safe_value}'")
 
         # update cursor if something is lost in the copy
         # of the parent connection

--- a/dbt/adapters/duckdb/environments/local.py
+++ b/dbt/adapters/duckdb/environments/local.py
@@ -103,7 +103,8 @@ class LocalEnvironment(Environment):
         cursor = handle.cursor()
 
         if source_config.schema:
-            cursor.execute(f"CREATE SCHEMA IF NOT EXISTS {source_config.schema}")
+            safe_schema = '"' + source_config.schema.replace('"', '""') + '"'
+            cursor.execute(f"CREATE SCHEMA IF NOT EXISTS {safe_schema}")
 
         save_mode = source_config.get("save_mode", "overwrite")
         if save_mode in ("ignore", "error_if_exists"):

--- a/dbt/adapters/duckdb/utils.py
+++ b/dbt/adapters/duckdb/utils.py
@@ -30,11 +30,17 @@ class SourceConfig:
     def __contains__(self, key):
         return key in self.meta
 
+    @staticmethod
+    def _quote_identifier(name: str) -> str:
+        """Quote a SQL identifier to prevent injection."""
+        return '"' + name.replace('"', '""') + '"'
+
     def table_name(self) -> str:
+        q = self._quote_identifier
         if self.database:
-            return ".".join([self.database, self.schema, self.identifier])
+            return ".".join([q(self.database), q(self.schema), q(self.identifier)])
         else:
-            return ".".join([self.schema, self.identifier])
+            return ".".join([q(self.schema), q(self.identifier)])
 
     def as_dict(self) -> Dict[str, Any]:
         base = {

--- a/tests/unit/test_sql_injection.py
+++ b/tests/unit/test_sql_injection.py
@@ -1,0 +1,83 @@
+import duckdb
+import pytest
+
+from dbt.adapters.duckdb.environments import Environment
+from dbt.adapters.duckdb.utils import SourceConfig
+
+
+class TestInitializeCursorEscaping:
+    """Verify that settings keys and values are sanitized in initialize_cursor."""
+
+    def _run_settings(self, settings: dict):
+        """Helper: create an in-memory cursor and apply settings through initialize_cursor."""
+        conn = duckdb.connect(":memory:")
+        cursor = conn.cursor()
+
+        # Build a minimal mock creds with only .settings, .retries, and .plugins used
+        class FakeCreds:
+            retries = None
+
+        creds = FakeCreds()
+        creds.settings = settings
+        Environment.initialize_cursor(creds, cursor, plugins=None, registered_df={})
+        return cursor, conn
+
+    def test_value_with_single_quote_does_not_inject(self):
+        """A value containing a single quote must not break out of the SQL string.
+
+        Without escaping this would be a syntax error or injection. With escaping,
+        DuckDB receives the full literal as one string and rejects it as an
+        invalid memory value -- that's the safe outcome (ParserException, not
+        a multi-statement injection).
+        """
+        with pytest.raises(Exception, match="Unknown unit for memory"):
+            self._run_settings({"memory_limit": "1GB'; DROP TABLE t;--"})
+
+    def test_key_with_double_quote_does_not_inject(self):
+        """A key containing special characters must be safely quoted."""
+        # A malicious key should just fail as an unknown setting, not inject SQL
+        with pytest.raises(Exception):
+            self._run_settings({'" ; DROP TABLE t; --': "1"})
+
+
+class TestSourceConfigQuoting:
+    """Verify that table_name() properly quotes identifiers."""
+
+    def test_simple_table_name(self):
+        sc = SourceConfig(
+            name="test", identifier="my_table", schema="my_schema",
+            database=None, meta={}, tags=[]
+        )
+        assert sc.table_name() == '"my_schema"."my_table"'
+
+    def test_table_name_with_database(self):
+        sc = SourceConfig(
+            name="test", identifier="my_table", schema="my_schema",
+            database="my_db", meta={}, tags=[]
+        )
+        assert sc.table_name() == '"my_db"."my_schema"."my_table"'
+
+    def test_table_name_escapes_double_quotes(self):
+        sc = SourceConfig(
+            name="test", identifier='tab"le', schema='sche"ma',
+            database=None, meta={}, tags=[]
+        )
+        assert sc.table_name() == '"sche""ma"."tab""le"'
+
+    def test_table_name_prevents_injection(self):
+        """A malicious identifier should be safely quoted, not executed."""
+        sc = SourceConfig(
+            name="test",
+            identifier='x"; DROP TABLE users; --',
+            schema="public",
+            database=None,
+            meta={},
+            tags=[],
+        )
+        name = sc.table_name()
+        # The entire malicious string is inside the quotes
+        assert name == '"public"."x""; DROP TABLE users; --"'
+
+    def test_quote_identifier_static(self):
+        assert SourceConfig._quote_identifier("hello") == '"hello"'
+        assert SourceConfig._quote_identifier('he"lo') == '"he""lo"'


### PR DESCRIPTION
## Summary

- Escape single quotes in setting values passed to `SET` in `initialize_cursor()` to prevent SQL injection via dbt profile YAML `settings`.
- Double-quote setting keys as SQL identifiers in `initialize_cursor()`.
- Quote schema and table identifiers in `SourceConfig.table_name()` and `load_source()` `CREATE SCHEMA` to prevent identifier injection.
- Add unit tests covering all sanitization paths.

## Background

`initialize_cursor()` in `environments/__init__.py` constructs `SET {key} = '{value}'` using raw string interpolation from dbt profile YAML. A malicious or accidental single quote in a setting value (e.g. `memory_limit: "1GB'; DROP TABLE t;--"`) could break out of the string literal. Similarly, schema and table names from `SourceConfig` were interpolated unquoted into DDL statements.

## Changes

| File | Change |
|------|--------|
| `environments/__init__.py` | Double-quote keys, escape `'` in values |
| `environments/local.py` | Double-quote schema in `CREATE SCHEMA IF NOT EXISTS` |
| `utils.py` | Add `_quote_identifier()`, use it in `table_name()` |
| `tests/unit/test_sql_injection.py` | 7 unit tests covering injection vectors |

## Test plan

- [x] All 99 existing unit tests pass (0 regressions)
- [x] 7 new tests verify injection is blocked for setting keys, setting values, schema names, and table identifiers