### PR TITLE
ci: add pytest-cov to unit test workflow for coverage reporting

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,7 +77,7 @@ jobs:
 
     env:
       TOXENV: "unit"
-      PYTEST_ADDOPTS: "-v --color=yes --csv unit_results.csv"
+      PYTEST_ADDOPTS: "-v --color=yes --csv unit_results.csv --cov=dbt/adapters/duckdb --cov-report=xml --cov-report=term-missing"
 
     steps:
       - name: Check out the repository

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -110,6 +110,13 @@ jobs:
           name: unit_results_${{ matrix.python-version }}-${{ steps.date.outputs.date }}.csv
           path: unit_results.csv
 
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: coverage-report-${{ matrix.python-version }}-${{ steps.date.outputs.date }}
+          path: coverage.xml
+
   functional:
     name: functional test / python ${{ matrix.python-version }}
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -29,6 +29,7 @@ psycopg2-binary
 psycopg[binary]
 pyiceberg
 pytest
+pytest-cov
 pytest-dotenv
 logbook<1.9  # pytest-logbook still imports logbook.compat
 pytest-logbook


### PR DESCRIPTION
## Summary
- Adds `pytest-cov` to `dev-requirements.txt`
- Enables coverage collection in the unit test CI job by appending `--cov=dbt/adapters/duckdb --cov-report=xml --cov-report=term-missing` to `PYTEST_ADDOPTS`
- Produces both terminal output with missing-line annotations and an XML coverage report for downstream tooling integration

## Test plan
- [ ] Verify unit test job still passes on all Python versions (3.10–3.13)
- [ ] Confirm coverage summary appears in CI logs (term-missing output)
- [ ] Confirm `coverage.xml` artifact is generated