### PR TITLE
Add duckdb__date dispatch macro

### DIFF
--- a/dbt/include/duckdb/macros/utils/date.sql
+++ b/dbt/include/duckdb/macros/utils/date.sql
@@ -1,0 +1,3 @@
+{% macro duckdb__date(year, month, day) -%}
+    make_date({{ year }}, {{ month }}, {{ day }})
+{%- endmacro %}

--- a/tests/functional/adapter/utils/test_utils.py
+++ b/tests/functional/adapter/utils/test_utils.py
@@ -8,6 +8,7 @@ from dbt.tests.adapter.utils.test_bool_or import BaseBoolOr
 from dbt.tests.adapter.utils.test_cast_bool_to_text import BaseCastBoolToText
 from dbt.tests.adapter.utils.test_concat import BaseConcat
 from dbt.tests.adapter.utils.test_current_timestamp import BaseCurrentTimestampNaive
+from dbt.tests.adapter.utils.test_date import BaseDate
 from dbt.tests.adapter.utils.test_date_trunc import BaseDateTrunc
 from dbt.tests.adapter.utils.test_dateadd import BaseDateAdd
 from dbt.tests.adapter.utils.test_datediff import BaseDateDiff
@@ -45,6 +46,10 @@ class TestCastBoolToText(BaseCastBoolToText):
 
 
 class TestConcat(BaseConcat):
+    pass
+
+
+class TestDate(BaseDate):
     pass
 
 


### PR DESCRIPTION
## Summary
`dbt.date()` (cross-database macro: https://docs.getdbt.com/reference/dbt-jinja-functions/cross-database-macros?version=2.0&name=Fusion#date-and-time-functions) dispatches to `default__date` when an adapter has no override, which emits `to_date('YYYY-MM-DD', 'YYYY-MM-DD')`. DuckDB has no `to_date` function, so any project calling `dbt.date_spine()` with `dbt.date()` boundaries (a documented usage pattern, see the `date_spine` macro's own docstring) fails on DuckDB.

This adds a `duckdb__date` override using DuckDB's native `make_date(year, month, day)`, mirroring the existing `bigquery__date` pattern in dbt-bigquery (native constructor instead of string parsing).

It also wires up the shared `BaseDate` test (`dbt.tests.adapter.utils.test_date`) into `test_utils.py`, the same way `TestDateAdd`/`TestDateDiff`/`TestDateTrunc` already are. That shared test happens to already build a `dbt.date_spine()` + `dbt.date()` model, so it directly exercises this fix.

Found and fixed while testing dbt-labs/jaffle-shop#103 against dbt-core 1.12 + DuckDB.

## Test plan
- [x] `pytest tests/functional/adapter/utils/test_utils.py` — 29 passed, 4 pre-existing skips, 0 failures (including the new `TestDate` case)
- [x] Manually verified `make_date(year, month, day)` plus interval arithmetic against DuckDB directly