### PR TITLE
fix: only strip query parameters from MotherDuck attach paths

### DIFF
--- a/dbt/adapters/duckdb/credentials.py
+++ b/dbt/adapters/duckdb/credentials.py
@@ -15,6 +15,8 @@ from dbt.adapters.contracts.connection import Credentials
 from dbt.adapters.duckdb.secrets import DEFAULT_SECRET_PREFIX
 from dbt.adapters.duckdb.secrets import Secret
 
+MOTHERDUCK_SCHEMES = {"md", "motherduck"}
+
 
 @dataclass
 class Attachment(dbtClassMixin):
@@ -44,9 +46,11 @@ class Attachment(dbtClassMixin):
     is_ducklake: Optional[bool] = None
 
     def to_sql(self) -> str:
-        # remove query parameters (not supported in ATTACH)
-        parsed = urlparse(self.path)
-        path = self.path.replace(f"?{parsed.query}", "")
+        # remove query parameters from MotherDuck paths (not supported in ATTACH)
+        path = self.path
+        parsed = urlparse(path)
+        if parsed.scheme in MOTHERDUCK_SCHEMES:
+            path = path.split("?", 1)[0]
         base = f"ATTACH IF NOT EXISTS '{path}'"
         if self.alias:
             base += f" AS {self.alias}"
@@ -319,7 +323,7 @@ class DuckDBCredentials(Credentials):
 
     @staticmethod
     def _is_motherduck(scheme: str) -> bool:
-        return scheme in {"md", "motherduck"}
+        return scheme in MOTHERDUCK_SCHEMES
 
     @staticmethod
     def path_derived_database_name(path: Optional[Any]) -> str:

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -237,6 +237,36 @@ def test_attachments():
         assert expected_sql[i] == attachment.to_sql()
 
 
+def test_attachment_strips_query_parameters_from_motherduck_paths():
+    assert (
+        Attachment(path="md:my_db?motherduck_token=abc123&user=1").to_sql()
+        == "ATTACH IF NOT EXISTS 'md:my_db'"
+    )
+    assert (
+        Attachment(path="motherduck:my_db?motherduck_token=abc123").to_sql()
+        == "ATTACH IF NOT EXISTS 'motherduck:my_db'"
+    )
+    assert (
+        Attachment(path="md:my_db?motherduck_token=ab#cd").to_sql()
+        == "ATTACH IF NOT EXISTS 'md:my_db'"
+    )
+    assert Attachment(path="md:my_db").to_sql() == "ATTACH IF NOT EXISTS 'md:my_db'"
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "postgresql://user@hostname/dbname?sslmode=require",
+        "https://example.com/db.duckdb?token=abc123",
+        "dbname=db host=h user=u password=aa?bb sslmode=require",
+        "dbname=db host=h user=u password=a#b?c sslmode=require",
+        "ducklake:postgres:dbname=meta host=h password=x?y",
+    ],
+)
+def test_attachment_preserves_query_parameters_for_non_motherduck_paths(path):
+    assert Attachment(path=path).to_sql() == f"ATTACH IF NOT EXISTS '{path}'"
+
+
 def test_attachments_with_options():
     # Test arbitrary options in options dict
     attachment = Attachment(


### PR DESCRIPTION
### Problem

`Attachment.to_sql()` strips the query string from every attach path. This was added in #444 to drop the MotherDuck token (`md:my_db?motherduck_token=...`) from the path, but there is no scheme check, so it applies to non-MotherDuck paths as well.

```python
from dbt.adapters.duckdb.credentials import Attachment

Attachment(path="postgresql://user@host/db?sslmode=require").to_sql()
# current:  "ATTACH IF NOT EXISTS 'postgresql://user@host/db'"
# expected: "ATTACH IF NOT EXISTS 'postgresql://user@host/db?sslmode=require'"
```

### Impact

- The README shows `path: postgresql://username@hostname/dbname` as the recommended form, but adding `?sslmode=require` to it is dropped with no warning or error.
- `?` is a legal character in a password. If a password contains `?`, everything from that point on is cut off and authentication fails.

### Changes

- Only strip the query string from `md:` / `motherduck:` scheme paths, and leave every other path unchanged.
- Replace `str.replace()` with a split on the first `?`.

### Tests

Added two tests to `tests/unit/test_credentials.py`:

- `test_attachment_strips_query_parameters_from_motherduck_paths` — pins the existing behavior for MotherDuck paths
- `test_attachment_preserves_query_parameters_for_non_motherduck_paths` — verifies that five non-MotherDuck paths pass through untouched
