### PR TITLE
Enable tests for DuckLake

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -165,6 +165,54 @@ jobs:
           name: functional_results_${{ matrix.python-version }}-${{ steps.date.outputs.date }}.csv
           path: functional_results.csv
 
+  ducklake:
+    name: DuckLake functional test / python ${{ matrix.python-version }}
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.10', '3.11', '3.12', '3.13']
+
+    env:
+      TOXENV: "ducklake"
+      PYTEST_ADDOPTS: "-v --color=yes --csv ducklake_results.csv"
+      S3_MD_ORG_KEY: ${{ secrets.S3_MD_ORG_KEY }}
+      S3_MD_ORG_REGION: ${{ secrets.S3_MD_ORG_REGION }}
+      S3_MD_ORG_SECRET: ${{ secrets.S3_MD_ORG_SECRET }}
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install python dependencies
+        run: |
+          python -m pip install tox
+          python -m pip --version
+          tox --version
+
+      - name: Run tox
+        run: tox
+
+      - name: Get current date
+        if: always()
+        id: date
+        run: echo "date=$(date +'%Y-%m-%dT%H_%M_%S')" >> $GITHUB_OUTPUT #no colons allowed for artifacts
+
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: ducklake_results_${{ matrix.python-version }}-${{ steps.date.outputs.date }}.csv
+          path: ducklake_results.csv
+
   filebased:
     name: file-based functional test / python ${{ matrix.python-version }}
 
@@ -283,6 +331,61 @@ jobs:
         with:
           name: motherduck_results_${{ matrix.python-version }}-${{ steps.date.outputs.date }}.csv
           path: motherduck_results.csv
+
+  motherduck-ducklake:
+    name: MotherDuck DuckLake functional test / python ${{ matrix.python-version }}
+    needs: [check-md-token]
+    if: needs.check-md-token.outputs.exists == 'true'
+
+    concurrency:
+      group: motherduck-functional-tests
+      cancel-in-progress: false
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.11']
+
+    env:
+      TOXENV: "md-ducklake"
+      MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN_10 }}
+      PYTEST_ADDOPTS: "-v --color=yes --csv motherduck_ducklake_results.csv"
+      S3_MD_ORG_KEY: ${{ secrets.S3_MD_ORG_KEY }}
+      S3_MD_ORG_REGION: ${{ secrets.S3_MD_ORG_REGION }}
+      S3_MD_ORG_SECRET: ${{ secrets.S3_MD_ORG_SECRET }}
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install python dependencies
+        run: |
+          python -m pip install tox
+          python -m pip --version
+          tox --version
+
+      - name: Run tox
+        run: tox
+
+      - name: Get current date
+        if: always()
+        id: date
+        run: echo "date=$(date +'%Y-%m-%dT%H_%M_%S')" >> $GITHUB_OUTPUT #no colons allowed for artifacts
+
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: motherduck_ducklake_results_${{ matrix.python-version }}-${{ steps.date.outputs.date }}.csv
+          path: motherduck_ducklake_results.csv
 
   buenavista:
     name: Buena Vista functional test / python ${{ matrix.python-version }}
@@ -505,7 +608,7 @@ jobs:
   notify-failure:
     name: Send Slack notification on failure
     if: failure() && github.ref == 'refs/heads/master'
-    needs: [code-quality, unit, functional, filebased, motherduck, buenavista, fsspec, plugins, build, test-build]
+    needs: [code-quality, unit, functional, ducklake, filebased, motherduck, motherduck-ducklake, buenavista, fsspec, plugins, build, test-build]
     runs-on: ubuntu-latest
     steps:
       - name: Send Slack notification

--- a/dbt/include/duckdb/macros/adapters.sql
+++ b/dbt/include/duckdb/macros/adapters.sql
@@ -309,6 +309,9 @@ def materialize(df, con):
 {% endmacro %}
 
 {% macro duckdb__make_temp_relation(base_relation, suffix) %}
+    {# Creates duckdb temporary tables, i.e. ephemeral per connection and on the temp.main schema.
+    Temporary tables are always allocated in the DuckdDB client's memory, even when called from a MotherDuck connection. #}
+
     {% set tmp_identifier = base_relation.identifier ~ suffix ~ py_current_timestring() %}
     {% do return(base_relation.incorporate(
                                   path={
@@ -318,22 +321,31 @@ def materialize(df, con):
                                   })) -%}
 {% endmacro %}
 
-{% macro duckdb__make_temporary_relation(target_relation, batch_id='') %}
-    {% set temporary = not adapter.is_motherduck() %}
-    {% set temporary_relation = make_temp_relation(target_relation) %}
+{% macro duckdb__dispatch_temporary_relation(target_relation, batch_id='') %}
+    {# Prepares a relation that is meant to be temporary.
 
-    {# MotherDuck requires a qualified regular table because it does not support remote temp tables. #}
-    {% if not temporary %}
-        {% set temporary_relation = temporary_relation.incorporate(
+     This macro is called when creating the temporary relations needed for incremental models and snapshots.
+
+     When running against duckdb,
+     it dispatches to standard dbt-core machinery to create a temporary table.
+     However, MotherDuck doesn't support server-side temporary tables,
+     so it dispatches to a fully qualified unique table relation under a temporary schema. #}
+
+    {% if adapter.is_motherduck() %}
+        {% set relation = target_relation.incorporate(
             path=adapter.get_temp_relation_path(target_relation, batch_id)
         ) %}
-        {% do run_query(create_schema(temporary_relation)) %}
+        {% do run_query(create_schema(relation)) %}
         {% if not adapter.disable_transactions() %}
             {% do adapter.commit() %}
         {% endif %}
+        {% do return({'relation': relation, 'temporary': false}) %}
+    {% else %}
+        {% do return({
+            'relation': make_temp_relation(target_relation),
+            'temporary': true
+        }) %}
     {% endif %}
-
-    {% do return({'relation': temporary_relation, 'temporary': temporary}) %}
 {% endmacro %}
 
 {% macro duckdb__current_timestamp() -%}

--- a/dbt/include/duckdb/macros/adapters.sql
+++ b/dbt/include/duckdb/macros/adapters.sql
@@ -318,6 +318,24 @@ def materialize(df, con):
                                   })) -%}
 {% endmacro %}
 
+{% macro duckdb__make_temporary_relation(target_relation, batch_id='') %}
+    {% set temporary = not adapter.is_motherduck() %}
+    {% set temporary_relation = make_temp_relation(target_relation) %}
+
+    {# MotherDuck requires a qualified regular table because it does not support remote temp tables. #}
+    {% if not temporary %}
+        {% set temporary_relation = temporary_relation.incorporate(
+            path=adapter.get_temp_relation_path(target_relation, batch_id)
+        ) %}
+        {% do run_query(create_schema(temporary_relation)) %}
+        {% if not adapter.disable_transactions() %}
+            {% do adapter.commit() %}
+        {% endif %}
+    {% endif %}
+
+    {% do return({'relation': temporary_relation, 'temporary': temporary}) %}
+{% endmacro %}
+
 {% macro duckdb__current_timestamp() -%}
   now()
 {%- endmacro %}

--- a/dbt/include/duckdb/macros/materializations/incremental.sql
+++ b/dbt/include/duckdb/macros/materializations/incremental.sql
@@ -32,6 +32,8 @@
   {{ drop_relation_if_exists(preexisting_backup_relation) }}
 
   {% set to_drop = [] %}
+   -- if not using a temporary table we will update the temp relation to use a different temp schema ("dbt_temp" by default)
+   -- for microbatch with concurrent batches, include batch timestamps in the identifier to avoid collisions
   {%- set batch_id = adapter.batch_id_for_model(model) -%}
   {% set temporary_relation = duckdb__make_temporary_relation(target_relation, batch_id) %}
   {% set temp_relation = temporary_relation.relation %}

--- a/dbt/include/duckdb/macros/materializations/incremental.sql
+++ b/dbt/include/duckdb/macros/materializations/incremental.sql
@@ -35,7 +35,7 @@
    -- if not using a temporary table we will update the temp relation to use a different temp schema ("dbt_temp" by default)
    -- for microbatch with concurrent batches, include batch timestamps in the identifier to avoid collisions
   {%- set batch_id = adapter.batch_id_for_model(model) -%}
-  {% set temporary_relation = duckdb__make_temporary_relation(target_relation, batch_id) %}
+  {% set temporary_relation = duckdb__dispatch_temporary_relation(target_relation, batch_id) %}
   {% set temp_relation = temporary_relation.relation %}
   {% set temporary = temporary_relation.temporary %}
   {% if not temporary %}

--- a/dbt/include/duckdb/macros/materializations/incremental.sql
+++ b/dbt/include/duckdb/macros/materializations/incremental.sql
@@ -1,13 +1,9 @@
 {% materialization incremental, adapter="duckdb", supported_languages=['sql', 'python'] -%}
 
   {%- set language = model['language'] -%}
-  -- only create temp tables if using local duckdb, as it is not currently supported for remote databases
-  {%- set temporary = not adapter.is_motherduck() -%}
-
   -- relations
   {%- set existing_relation = load_cached_relation(this) -%}
   {%- set target_relation = this.incorporate(type='table') -%}
-  {%- set temp_relation = make_temp_relation(target_relation)-%}
   {%- set intermediate_relation = make_intermediate_relation(target_relation)-%}
   {%- set backup_relation_type = 'table' if existing_relation is none else existing_relation.type -%}
   {%- set backup_relation = make_backup_relation(target_relation, backup_relation_type) -%}
@@ -36,16 +32,11 @@
   {{ drop_relation_if_exists(preexisting_backup_relation) }}
 
   {% set to_drop = [] %}
+  {%- set batch_id = adapter.batch_id_for_model(model) -%}
+  {% set temporary_relation = duckdb__make_temporary_relation(target_relation, batch_id) %}
+  {% set temp_relation = temporary_relation.relation %}
+  {% set temporary = temporary_relation.temporary %}
   {% if not temporary %}
-    -- if not using a temporary table we will update the temp relation to use a different temp schema ("dbt_temp" by default)
-    -- for microbatch with concurrent batches, include batch timestamps in the identifier to avoid collisions
-    {%- set batch_id = adapter.batch_id_for_model(model) -%}
-    {% set temp_relation = temp_relation.incorporate(path=adapter.get_temp_relation_path(this, batch_id)) %}
-    {% do run_query(create_schema(temp_relation)) %}
-    {% if not adapter.disable_transactions() %}
-      {% do adapter.commit() %}
-    {% endif %}
-    -- then drop the temp relation after we insert the incremental data into the target relation
     {% do to_drop.append(temp_relation) %}
   {% endif %}
 

--- a/dbt/include/duckdb/macros/materializations/incremental_strategy/merge_config_validation.sql
+++ b/dbt/include/duckdb/macros/materializations/incremental_strategy/merge_config_validation.sql
@@ -22,9 +22,11 @@
     {%- endif -%}
   {%- endfor -%}
 
-  {%- do validate_ducklake_restrictions(config, target_relation, errors) -%}
-
   {%- do validate_merge_clauses(config, base_configuration_fields, errors) -%}
+
+  {%- if not errors -%}
+    {%- do validate_ducklake_restrictions(config, target_relation, errors) -%}
+  {%- endif -%}
 
   {%- if errors -%}
     {{ exceptions.raise_compiler_error("MERGE configuration errors:\n" ~ errors|join('\n')) }}
@@ -95,21 +97,19 @@
 {%- endmacro -%}
 
 {%- macro validate_ducklake_restrictions(config, target_relation, errors) -%}
-  {%- if target_relation and adapter.is_ducklake(target_relation) -%}
-    {%- set merge_clauses = config.get('merge_clauses', {}) -%}
-    {%- if merge_clauses and 'when_matched' in merge_clauses -%}
-      {%- set when_matched_clauses = merge_clauses.get('when_matched', []) -%}
-      {%- set update_delete_count = 0 -%}
+  {%- if not target_relation or not adapter.is_ducklake(target_relation) -%}
+    {%- do return(none) -%}
+  {%- endif -%}
 
-      {%- for clause in when_matched_clauses -%}
-        {%- if clause is mapping and clause.get('action') in ['update', 'delete'] -%}
-          {%- set update_delete_count = update_delete_count + 1 -%}
-        {%- endif -%}
-      {%- endfor -%}
+  {%- if config.get('merge_returning_columns') -%}
+    {%- do errors.append("DuckLake MERGE restrictions: merge_returning_columns is not supported because DuckLake does not support RETURNING.") -%}
+  {%- endif -%}
 
-      {%- if update_delete_count > 1 -%}
-        {%- do errors.append("DuckLake MERGE restrictions: when_matched clauses can contain only a single UPDATE or DELETE action. Found " ~ update_delete_count ~ " UPDATE/DELETE actions. DuckLake currently supports only one UPDATE or DELETE operation per MERGE statement.") -%}
-      {%- endif -%}
-    {%- endif -%}
+  {%- set unsupported_clauses = ['update', 'delete'] -%}
+  {%- set merge_clauses = config.get('merge_clauses') or {} -%}
+  {%- set configured_clauses = merge_clauses.get('when_matched', []) + merge_clauses.get('when_not_matched', []) -%}
+  {%- set unsupported_configured_clauses = configured_clauses | selectattr('action', 'defined') | selectattr('action', 'in', unsupported_clauses) | list -%}
+  {%- if unsupported_configured_clauses|length > 1 -%}
+    {%- do errors.append("DuckLake MERGE restrictions: merge_clauses can contain only a single UPDATE or DELETE action across when_matched and when_not_matched. Found " ~ unsupported_configured_clauses|length ~ " UPDATE/DELETE actions. DuckLake currently supports only one UPDATE or DELETE operation per MERGE statement.") -%}
   {%- endif -%}
 {%- endmacro -%}

--- a/dbt/include/duckdb/macros/snapshot_helper.sql
+++ b/dbt/include/duckdb/macros/snapshot_helper.sql
@@ -24,17 +24,19 @@
 {% endmacro %}
 
 {% macro build_snapshot_staging_table(strategy, sql, target_relation) %}
-    {% set temp_relation = make_temp_relation(target_relation) %}
+    {% set temporary_relation = duckdb__make_temporary_relation(target_relation) %}
+    {% set temp_relation = temporary_relation.relation %}
+    {% set temporary = temporary_relation.temporary %}
 
     {% set select = snapshot_staging_table(strategy, sql, target_relation) %}
 
     {% call statement('build_snapshot_staging_relation') %}
-        {{ create_table_as(False, temp_relation, select) }}
+        {{ create_table_as(temporary, temp_relation, select) }}
     {% endcall %}
 
     {% do return(temp_relation) %}
 {% endmacro %}
 
-{% macro duckdb__post_snapshot(staging_relation) %}
-    {% do return(drop_relation(staging_relation)) %}
+{% macro duckdb__post_snapshot(temporary_relation) %}
+    {% do return(drop_relation(temporary_relation)) %}
 {% endmacro %}

--- a/dbt/include/duckdb/macros/snapshot_helper.sql
+++ b/dbt/include/duckdb/macros/snapshot_helper.sql
@@ -24,7 +24,7 @@
 {% endmacro %}
 
 {% macro build_snapshot_staging_table(strategy, sql, target_relation) %}
-    {% set temporary_relation = duckdb__make_temporary_relation(target_relation) %}
+    {% set temporary_relation = duckdb__dispatch_temporary_relation(target_relation) %}
     {% set temp_relation = temporary_relation.relation %}
     {% set temporary = temporary_relation.temporary %}
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,4 +6,7 @@ testpaths =
     tests/functional
     tests/unit
 markers =
+    requires_ducklake
+    skip_database_type(database_type)
     skip_profile(profile)
+    with_s3_creds

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
+addopts = --strict-markers
 filterwarnings =
     ignore:.*'soft_unicode' has been renamed to 'soft_str'*:DeprecationWarning
     ignore:unclosed file .*:ResourceWarning

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,6 @@ import duckdb
 import pytest
 
 from tests.ducklake import configure_ducklake_profile
-from tests.ducklake import create_motherduck_database_sql
 
 # Increase the number of open files allowed
 # Hack for https://github.com/dbt-labs/dbt-core/issues/7316
@@ -33,6 +32,12 @@ TEST_MOTHERDUCK_TOKEN = "TEST_MOTHERDUCK_TOKEN"
 # "Can't open a connection to same database file with a different configuration
 # than existing connections".
 MD_TEST_CONFIG_OPTIONS = {"motherduck_dbinstance_inactivity_ttl": "0s"}
+
+
+def create_motherduck_database_sql(database_name: str, database_type: str) -> str:
+    if database_type == "ducklake":
+        return f"CREATE OR REPLACE DATABASE {database_name} (TYPE ducklake)"
+    return f"CREATE OR REPLACE DATABASE {database_name}"
 
 
 def pytest_addoption(parser):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,12 @@ pytest_plugins = ["dbt.tests.fixtures.project"]
 
 MOTHERDUCK_TOKEN = "MOTHERDUCK_TOKEN"
 TEST_MOTHERDUCK_TOKEN = "TEST_MOTHERDUCK_TOKEN"
+PROFILE_TYPES = ("memory", "file", "md", "buenavista", "nightly")
+DATABASE_TYPES = ("duckdb", "ducklake")
+CONFIG_SKIP_MARKERS = {
+    "skip_profile": ("--profile", PROFILE_TYPES, "profile"),
+    "skip_database_type": ("--database-type", DATABASE_TYPES, "database type"),
+}
 
 # This option cleans up each test's duckdb instance as soon as the duckdbPyConnection
 # closes instead of allowing it to live in the instance cache for reuse on the next
@@ -41,11 +47,13 @@ def create_motherduck_database_sql(database_name: str, database_type: str) -> st
 
 
 def pytest_addoption(parser):
-    parser.addoption("--profile", action="store", default="memory", type=str)
+    parser.addoption(
+        "--profile", action="store", choices=PROFILE_TYPES, default="memory", type=str
+    )
     parser.addoption(
         "--database-type",
         action="store",
-        choices=("duckdb", "ducklake"),
+        choices=DATABASE_TYPES,
         default="duckdb",
         type=str,
     )
@@ -157,35 +165,57 @@ def dbt_profile_target(profile_type, database_type, bv_server_process, tmpdir_fa
     return profile
 
 
-@pytest.fixture(autouse=True, scope="class")
-def skip_by_profile_type(profile_type, request):
-    if request.node.get_closest_marker("skip_profile"):
-        for skip_profile_type in request.node.get_closest_marker("skip_profile").args:
-            if skip_profile_type == profile_type:
-                pytest.skip(f"skipped on '{profile_type}' profile")
-
-
-@pytest.fixture(autouse=True, scope="class")
-def skip_by_database_type(database_type, request):
-    for marker in request.node.iter_markers("skip_database_type"):
-        if database_type in marker.args:
-            pytest.skip(f"skipped on '{database_type}' database type")
-
-
-@pytest.fixture(autouse=True)
-def skip_test_by_database_type(database_type, request):
-    for marker in request.node.iter_markers("skip_database_type"):
-        if database_type in marker.args:
-            pytest.skip(f"skipped on '{database_type}' database type")
-
-
 @pytest.fixture(scope="session")
 def test_data_path():
     test_dir = os.path.dirname(os.path.abspath(__file__))
     return os.path.join(test_dir, "data")
 
 
+def mark_skipped_by_config(items, marker_name, selected_value):
+    """Apply skip marks based on the testing configuration of a particular run.
+
+    pytest_collection_modifyitems() calls this function for each entry
+    on CONFIG_SKIP_MARKERS.
+    """
+    try:
+        _, known_values, value_description = CONFIG_SKIP_MARKERS[marker_name]
+    except KeyError:
+        raise pytest.UsageError(f"Unknown config skip marker: {marker_name}") from None
+
+    for item in items:
+        for marker in item.iter_markers(marker_name):
+            unknown_values = [value for value in marker.args if value not in known_values]
+            if not marker.args or unknown_values:
+                supplied_values = ", ".join(repr(value) for value in marker.args) or "none"
+                expected_values = ", ".join(repr(value) for value in known_values)
+                raise pytest.UsageError(
+                    f"{item.nodeid}: {marker_name} has unknown {value_description} "
+                    f"value(s) {supplied_values}; expected one or more of {expected_values}"
+                )
+
+            if selected_value in marker.args:
+                reason = marker.kwargs.get(
+                    "reason", f"skipped on '{selected_value}' {value_description}"
+                )
+                item.add_marker(pytest.mark.skip(reason=reason))
+                break
+
+
 def pytest_collection_modifyitems(config, items):
+    """Apply skip marker during collection.
+
+    Implementing skips this way offers two benefits:
+    - It allows to verify that the skip parameters are valid (no typos).
+    - Skips are applied before any fixture is initialized, so only fixtures
+    that are needed for each testing config are initialized.
+
+    Pytest calls this hook after collecting test items, but before initializing anything.
+    - It converts the custom profile and database-type markers into Pytest skips,
+    - Also skips tests when there are no valid s3 credentials or the DuckLake extension is unavailable.
+    """
+    for marker_name, (option_name, _, _) in CONFIG_SKIP_MARKERS.items():
+        mark_skipped_by_config(items, marker_name, config.getoption(option_name))
+
     skip_s3 = None
     # Skip the S3 tests if the secrets are not available
     if not (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,9 @@ from importlib import metadata
 import duckdb
 import pytest
 
+from tests.ducklake import configure_ducklake_profile
+from tests.ducklake import create_motherduck_database_sql
+
 # Increase the number of open files allowed
 # Hack for https://github.com/dbt-labs/dbt-core/issues/7316
 soft_limit, hard_limit = resource.getrlimit(resource.RLIMIT_NOFILE)
@@ -24,7 +27,7 @@ TEST_MOTHERDUCK_TOKEN = "TEST_MOTHERDUCK_TOKEN"
 # This option cleans up each test's duckdb instance as soon as the duckdbPyConnection
 # closes instead of allowing it to live in the instance cache for reuse on the next
 # `duckdb.connect(<same path>)`.
-# Every test profile whose *primary* database is `md:{database_name}` must include 
+# Every test profile whose *primary* database is `md:{database_name}` must include
 # this in its config_options: a lingering instance from a profile without it makes
 # the next test's connection to the same `md:{database_name}`` path fail with
 # "Can't open a connection to same database file with a different configuration
@@ -34,6 +37,13 @@ MD_TEST_CONFIG_OPTIONS = {"motherduck_dbinstance_inactivity_ttl": "0s"}
 
 def pytest_addoption(parser):
     parser.addoption("--profile", action="store", default="memory", type=str)
+    parser.addoption(
+        "--database-type",
+        action="store",
+        choices=("duckdb", "ducklake"),
+        default="duckdb",
+        type=str,
+    )
 
 
 def pytest_report_header() -> list[str]:
@@ -50,7 +60,12 @@ def profile_type(request):
 
 
 @pytest.fixture(scope="session")
-def test_database_name():
+def database_type(request):
+    return request.config.getoption("--database-type")
+
+
+@pytest.fixture(scope="session")
+def test_database_name(database_type):
     """Generate a unique database name for the entire MotherDuck test session
 
     The suffix is deliberately letters-only (no digits): several functional
@@ -66,7 +81,7 @@ def test_database_name():
     token = os.environ.get(MOTHERDUCK_TOKEN) or os.environ.get(TEST_MOTHERDUCK_TOKEN)
     if token:
         conn = duckdb.connect(f"md:?motherduck_token={token}")
-        conn.execute(f"CREATE DATABASE IF NOT EXISTS {db_name}")
+        conn.execute(create_motherduck_database_sql(db_name, database_type))
         conn.close()
 
     yield db_name
@@ -99,7 +114,7 @@ def bv_server_process(profile_type):
 # The profile dictionary, used to write out profiles.yml
 # dbt will supply a unique schema per test, so we do not specify 'schema' here
 @pytest.fixture(scope="session")
-def dbt_profile_target(profile_type, bv_server_process, tmpdir_factory, request):
+def dbt_profile_target(profile_type, database_type, bv_server_process, tmpdir_factory, request):
     profile = {"type": "duckdb", "threads": 4}
 
     if profile_type == "buenavista":
@@ -131,6 +146,9 @@ def dbt_profile_target(profile_type, bv_server_process, tmpdir_factory, request)
     else:
         raise ValueError(f"Invalid profile type '{profile_type}'")
 
+    if database_type == "ducklake":
+        configure_ducklake_profile(profile, profile_type, tmpdir_factory)
+
     return profile
 
 
@@ -140,6 +158,20 @@ def skip_by_profile_type(profile_type, request):
         for skip_profile_type in request.node.get_closest_marker("skip_profile").args:
             if skip_profile_type == profile_type:
                 pytest.skip(f"skipped on '{profile_type}' profile")
+
+
+@pytest.fixture(autouse=True, scope="class")
+def skip_by_database_type(database_type, request):
+    for marker in request.node.iter_markers("skip_database_type"):
+        if database_type in marker.args:
+            pytest.skip(f"skipped on '{database_type}' database type")
+
+
+@pytest.fixture(autouse=True)
+def skip_test_by_database_type(database_type, request):
+    for marker in request.node.iter_markers("skip_database_type"):
+        if database_type in marker.args:
+            pytest.skip(f"skipped on '{database_type}' database type")
 
 
 @pytest.fixture(scope="session")

--- a/tests/ducklake.py
+++ b/tests/ducklake.py
@@ -21,9 +21,3 @@ def configure_ducklake_profile(
         profile["path"] = f"ducklake:{root / 'catalog.ducklake'}"
     else:
         profile["is_ducklake"] = True
-
-
-def create_motherduck_database_sql(database_name: str, database_type: str) -> str:
-    if database_type == "ducklake":
-        return f"CREATE DATABASE {database_name} (TYPE ducklake)"
-    return f"CREATE DATABASE IF NOT EXISTS {database_name}"

--- a/tests/ducklake.py
+++ b/tests/ducklake.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+from typing import Any
+
+SUPPORTED_DUCKLAKE_PROFILES = {"memory", "md"}
+
+
+def configure_ducklake_profile(
+    profile: dict[str, Any], profile_type: str, tmpdir_factory: Any
+) -> None:
+    if profile_type not in SUPPORTED_DUCKLAKE_PROFILES:
+        supported = ", ".join(sorted(SUPPORTED_DUCKLAKE_PROFILES))
+        raise ValueError(
+            f"DuckLake databases are only supported for these test profiles: {supported}"
+        )
+
+    # Concurrent dbt writers can lose DuckLake staging relations across connections.
+    profile["threads"] = 1
+
+    if profile_type == "memory":
+        root = Path(tmpdir_factory.mktemp("ducklake"))
+        profile["path"] = f"ducklake:{root / 'catalog.ducklake'}"
+    else:
+        profile["is_ducklake"] = True
+
+
+def create_motherduck_database_sql(database_name: str, database_type: str) -> str:
+    if database_type == "ducklake":
+        return f"CREATE DATABASE {database_name} (TYPE ducklake)"
+    return f"CREATE DATABASE IF NOT EXISTS {database_name}"

--- a/tests/functional/adapter/indexes/test_indexes.py
+++ b/tests/functional/adapter/indexes/test_indexes.py
@@ -15,6 +15,7 @@ from tests.functional.adapter.indexes.fixtures import (
 INDEX_DEFINITION_PATTERN = re.compile(r"\((.*?)\)")
 
 
+@pytest.mark.skip_database_type("ducklake", reason="DuckLake does not support indexes")
 class TestIndex:
     @pytest.fixture(scope="class")
     def models(self):

--- a/tests/functional/adapter/test_basic.py
+++ b/tests/functional/adapter/test_basic.py
@@ -135,18 +135,10 @@ class TestGenericTestsDuckDB(BaseGenericTests):
     pass
 
 
-@pytest.mark.skip_database_type(
-    "ducklake",
-    reason="dbt snapshot execution still reaches a CASCADE drop that DuckLake rejects",
-)
 class TestSnapshotCheckColsDuckDB(BaseSnapshotCheckCols):
     pass
 
 
-@pytest.mark.skip_database_type(
-    "ducklake",
-    reason="dbt snapshot execution still reaches a CASCADE drop that DuckLake rejects",
-)
 class TestSnapshotTimestampDuckDB(BaseSnapshotTimestamp):
     pass
 

--- a/tests/functional/adapter/test_basic.py
+++ b/tests/functional/adapter/test_basic.py
@@ -126,6 +126,7 @@ class TestEphemeralDuckDB(BaseEphemeral):
 class TestIncrementalDuckDB(BaseIncremental):
     pass
 
+
 class TestBaseIncrementalNotSchemaChange(BaseIncrementalNotSchemaChange):
     pass
 
@@ -134,10 +135,18 @@ class TestGenericTestsDuckDB(BaseGenericTests):
     pass
 
 
+@pytest.mark.skip_database_type(
+    "ducklake",
+    reason="dbt snapshot execution still reaches a CASCADE drop that DuckLake rejects",
+)
 class TestSnapshotCheckColsDuckDB(BaseSnapshotCheckCols):
     pass
 
 
+@pytest.mark.skip_database_type(
+    "ducklake",
+    reason="dbt snapshot execution still reaches a CASCADE drop that DuckLake rejects",
+)
 class TestSnapshotTimestampDuckDB(BaseSnapshotTimestamp):
     pass
 

--- a/tests/functional/adapter/test_constraints.py
+++ b/tests/functional/adapter/test_constraints.py
@@ -12,6 +12,11 @@ from dbt.tests.adapter.constraints.test_constraints import (
 )
 
 
+pytestmark = pytest.mark.skip_database_type(
+    "ducklake", reason="DuckLake does not support primary or unique constraints"
+)
+
+
 class DuckDBColumnEqualSetup:
     @pytest.fixture
     def int_type(self):

--- a/tests/functional/adapter/test_database_type.py
+++ b/tests/functional/adapter/test_database_type.py
@@ -1,0 +1,22 @@
+def test_requested_database_type(project, database_type, profile_type):
+    """
+    Sanity check the target database type.
+    DuckLake's are declared differently on MotherDuck targets than on vanilla DuckDB.
+    """
+    if database_type != "ducklake":
+        return
+
+    # DuckLake on motherduck has type = 'motherduck' on duckdb_databases()
+    if profile_type == "md":
+        assert project.adapter.config.credentials.is_ducklake is True
+        return
+
+    database_storage_type = project.run_sql(
+        """
+        select type
+        from duckdb_databases()
+        where database_name = current_database()
+        """,
+        fetch="one",
+    )[0]
+    assert database_storage_type.lower() == "ducklake"

--- a/tests/functional/adapter/test_database_type.py
+++ b/tests/functional/adapter/test_database_type.py
@@ -1,14 +1,20 @@
 def test_requested_database_type(project, database_type, profile_type):
     """
-    Sanity check the target database type.
-    DuckLake's are declared differently on MotherDuck targets than on vanilla DuckDB.
-    """
-    if database_type != "ducklake":
-        return
+    Sanity check the physical and adapter-level target database types.
 
-    # DuckLake on motherduck has type = 'motherduck' on duckdb_databases()
-    if profile_type == "md":
-        assert project.adapter.config.credentials.is_ducklake is True
+    DuckLake databases are declared differently on MotherDuck targets than on
+    local DuckDB targets.
+    """
+    database_name = project.run_sql("select current_database()", fetch="one")[0]
+    relation = project.adapter.Relation.create(
+        database=database_name,
+        schema="main",
+        identifier="test_relation",
+    )
+
+    assert project.adapter.is_ducklake(relation) is (database_type == "ducklake")
+
+    if database_type != "ducklake" or profile_type == "md":
         return
 
     database_storage_type = project.run_sql(

--- a/tests/functional/adapter/test_ducklake_features.py
+++ b/tests/functional/adapter/test_ducklake_features.py
@@ -1,0 +1,78 @@
+import pytest
+from dbt.tests.util import run_dbt
+
+
+models__partitioned_and_sorted = """
+{{ config(materialized='table', partitioned_by='ds', sorted_by='region') }}
+
+select 1 as id, '2025-01-01' as ds, 'us' as region
+union all
+select 2 as id, '2025-01-02' as ds, 'eu' as region
+"""
+
+
+@pytest.mark.skip_database_type(
+    "duckdb", reason="This test validates DuckLake-specific table configuration"
+)
+class TestDuckLakeFeatures:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"partitioned_and_sorted.sql": models__partitioned_and_sorted}
+
+    def test_partition_and_sort_order(self, project, profile_type):
+        run_dbt(["run", "--select", "partitioned_and_sorted"])
+        result = run_dbt(["run", "--select", "partitioned_and_sorted"])
+        node = result.results[0].node
+
+        relation = project.adapter.Relation.create(
+            database=node.database,
+            schema=node.schema,
+            identifier=node.alias,
+        )
+        assert project.run_sql(f"select count(*) from {relation}", fetch="one")[0] == 2
+
+        # Managed DuckLake does not expose its internal metadata schema.
+        if profile_type == "md":
+            return
+
+        metadata_schema = f"__ducklake_metadata_{node.database}"
+
+        partition_columns = project.run_sql(
+            f"""
+            select c.column_name
+            from {metadata_schema}.ducklake_partition_column pc
+            join {metadata_schema}.ducklake_column c
+              on c.table_id = pc.table_id
+             and c.column_id = pc.column_id
+            join {metadata_schema}.ducklake_table t on t.table_id = c.table_id
+            join {metadata_schema}.ducklake_schema s on s.schema_id = t.schema_id
+            where lower(t.table_name) = lower('{node.alias}')
+              and lower(s.schema_name) = lower('{node.schema}')
+              and t.end_snapshot is null
+              and c.end_snapshot is null
+              and s.end_snapshot is null
+            order by c.column_id
+            """,
+            fetch="all",
+        )
+        sort_expressions = project.run_sql(
+            f"""
+            select se.expression
+            from {metadata_schema}.ducklake_sort_info si
+            join {metadata_schema}.ducklake_sort_expression se
+              on se.sort_id = si.sort_id
+             and se.table_id = si.table_id
+            join {metadata_schema}.ducklake_table t on t.table_id = si.table_id
+            join {metadata_schema}.ducklake_schema s on s.schema_id = t.schema_id
+            where lower(t.table_name) = lower('{node.alias}')
+              and lower(s.schema_name) = lower('{node.schema}')
+              and t.end_snapshot is null
+              and s.end_snapshot is null
+              and si.end_snapshot is null
+            order by se.sort_key_index
+            """,
+            fetch="all",
+        )
+
+        assert [row[0].lower() for row in partition_columns] == ["ds"]
+        assert [row[0].lower() for row in sort_expressions] == ["region"]

--- a/tests/functional/adapter/test_ducklake_partitioned_by.py
+++ b/tests/functional/adapter/test_ducklake_partitioned_by.py
@@ -169,6 +169,9 @@ class TestDucklakePartitionedByCompile(BasePartitionedByCompile):
         )
 
 
+@pytest.mark.skip_database_type(
+    "ducklake", reason="This test validates behavior on a non-DuckLake database"
+)
 class TestNonDucklakePartitionedByCompile(BasePartitionedByCompile):
     @pytest.fixture(scope="class")
     def dbt_profile_target(self, dbt_profile_target):

--- a/tests/functional/adapter/test_ducklake_partitioned_by_integration.py
+++ b/tests/functional/adapter/test_ducklake_partitioned_by_integration.py
@@ -171,6 +171,9 @@ class TestDucklakePartitionedByIntegration(BaseDucklakePartitionedBy):
 
 
 @pytest.mark.skip_profile("buenavista")
+@pytest.mark.skip_database_type(
+    "ducklake", reason="This test validates behavior on a non-DuckLake database"
+)
 class TestNonDucklakePartitionedBy:
     @pytest.fixture(scope="class")
     def models(self):
@@ -215,4 +218,3 @@ class TestPartitionedByValidation(BaseDucklakePartitionedBy):
         """Invalid identifier is quoted and DuckDB rejects it as a nonexistent column."""
         result = run_dbt(["run", "--select", "invalid_partitioned_by_string"], expect_pass=False)
         assert "does not exist" in str(result.results[0].message)
-

--- a/tests/functional/adapter/test_ducklake_sorted_by.py
+++ b/tests/functional/adapter/test_ducklake_sorted_by.py
@@ -173,6 +173,9 @@ class TestDucklakeSortedByCompile(BaseSortedByCompile):
         )
 
 
+@pytest.mark.skip_database_type(
+    "ducklake", reason="This test validates behavior on a non-DuckLake database"
+)
 class TestNonDucklakeSortedByCompile(BaseSortedByCompile):
     @pytest.fixture(scope="class")
     def dbt_profile_target(self, dbt_profile_target):

--- a/tests/functional/adapter/test_ducklake_sorted_by_integration.py
+++ b/tests/functional/adapter/test_ducklake_sorted_by_integration.py
@@ -185,6 +185,9 @@ class TestDucklakeSortedByIntegration(BaseDucklakeSortedBy):
 
 
 @pytest.mark.skip_profile("buenavista")
+@pytest.mark.skip_database_type(
+    "ducklake", reason="This test validates behavior on a non-DuckLake database"
+)
 class TestNonDucklakeSortedBy:
     @pytest.fixture(scope="class")
     def models(self):

--- a/tests/functional/adapter/test_incremental.py
+++ b/tests/functional/adapter/test_incremental.py
@@ -463,6 +463,40 @@ _merge_ducklake_update_delete = """
 SELECT 1 AS id, 'Alice' AS name, 25 AS age, 'Engineer' AS job
 """
 
+_merge_ducklake_cross_clause_actions = """
+{{ config(
+    materialized='incremental',
+    incremental_strategy='merge',
+    unique_key='id',
+    merge_clauses={
+        'when_matched': [
+            {'action': 'update', 'mode': 'by_name'}
+        ],
+        'when_not_matched': [
+            {'by': 'source', 'action': 'delete'}
+        ]
+    }
+) }}
+
+SELECT 1 AS id, 'Alice' AS name, 25 AS age, 'Engineer' AS job
+"""
+
+_merge_ducklake_multiple_not_matched_actions = """
+{{ config(
+    materialized='incremental',
+    incremental_strategy='merge',
+    unique_key='id',
+    merge_clauses={
+        'when_not_matched': [
+            {'by': 'source', 'action': 'update', 'set_expressions': {'name': "'Missing'"}},
+            {'by': 'source', 'action': 'delete'}
+        ]
+    }
+) }}
+
+SELECT 1 AS id, 'Alice' AS name, 25 AS age, 'Engineer' AS job
+"""
+
 _merge_ducklake_valid_single_update = """
 {{ config(
     materialized='incremental',
@@ -618,8 +652,11 @@ class TestIncrementalMergeValidation:
             "merge_empty_clauses.sql": _merge_empty_clauses,
             "merge_invalid_clause_list.sql": _merge_invalid_clause_list,
             "merge_invalid_clause_element.sql": _merge_invalid_clause_element,
+            "merge_ducklake_returning.sql": _merge_with_returning,
             "merge_ducklake_multiple_updates.sql": _merge_ducklake_multiple_updates,
             "merge_ducklake_update_delete.sql": _merge_ducklake_update_delete,
+            "merge_ducklake_cross_clause_actions.sql": _merge_ducklake_cross_clause_actions,
+            "merge_ducklake_multiple_not_matched_actions.sql": _merge_ducklake_multiple_not_matched_actions,
             "merge_ducklake_valid_single_update.sql": _merge_ducklake_valid_single_update,
         }
 
@@ -674,33 +711,34 @@ class TestIncrementalMergeValidation:
         result = run_dbt(["run", "--select", "merge_invalid_clause_element"], expect_pass=False)
         assert "elements must be dictionaries, found: not_a_dict" in str(result.results[0].message)
 
-    # NOTE: The following DuckLake tests require a DuckLake attachment to be active
-    # They will only trigger validation errors when the target relation is in a ducklake database
-    def test_ducklake_multiple_updates(self, project):
-        """Test DuckLake restriction fails for multiple UPDATE actions (in ducklake environments)"""
-        run_dbt(["run", "--select", "merge_ducklake_multiple_updates"], expect_pass=True)
-        try:
-            # This will pass in non-ducklake environments, fail in ducklake environments
-            result = run_dbt(["run", "--select", "merge_ducklake_multiple_updates"], expect_pass=False)
-            # If we get here, it means the run failed (ducklake environment)
-            assert "DuckLake MERGE restrictions" in str(result.results[0].message)
-            assert "can contain only a single UPDATE or DELETE action" in str(result.results[0].message)
-        except AssertionError:
-            # Run passed - we're in a non-ducklake environment, validation was skipped
-            pass
+    @pytest.mark.skip_database_type(
+        "duckdb", reason="This test validates a DuckLake-specific MERGE restriction"
+    )
+    def test_ducklake_returning(self, project):
+        """Test DuckLake restriction fails for RETURNING."""
+        run_dbt(["run", "--select", "merge_ducklake_returning"], expect_pass=True)
+        result = run_dbt(["run", "--select", "merge_ducklake_returning"], expect_pass=False)
+        assert "DuckLake MERGE restrictions" in str(result.results[0].message)
+        assert "merge_returning_columns is not supported" in str(result.results[0].message)
 
-    def test_ducklake_update_delete(self, project):
-        """Test DuckLake restriction fails for UPDATE + DELETE actions (in ducklake environments)"""
-        run_dbt(["run", "--select", "merge_ducklake_update_delete"], expect_pass=True)
-        try:
-            # This will pass in non-ducklake environments, fail in ducklake environments
-            result = run_dbt(["run", "--select", "merge_ducklake_update_delete"], expect_pass=False)
-            # If we get here, it means the run failed (ducklake environment)
-            assert "DuckLake MERGE restrictions" in str(result.results[0].message)
-            assert "Found 2 UPDATE/DELETE actions" in str(result.results[0].message)
-        except AssertionError:
-            # Run passed - we're in a non-ducklake environment, validation was skipped
-            pass
+    @pytest.mark.skip_database_type(
+        "duckdb", reason="This test validates a DuckLake-specific MERGE restriction"
+    )
+    @pytest.mark.parametrize(
+        "model_name",
+        [
+            "merge_ducklake_multiple_updates",
+            "merge_ducklake_update_delete",
+            "merge_ducklake_cross_clause_actions",
+            "merge_ducklake_multiple_not_matched_actions",
+        ],
+    )
+    def test_ducklake_multiple_update_delete_actions(self, project, model_name):
+        """Test DuckLake restriction fails for multiple UPDATE/DELETE actions."""
+        run_dbt(["run", "--select", model_name], expect_pass=True)
+        result = run_dbt(["run", "--select", model_name], expect_pass=False)
+        assert "DuckLake MERGE restrictions" in str(result.results[0].message)
+        assert "Found 2 UPDATE/DELETE actions" in str(result.results[0].message)
 
     def test_ducklake_valid_single_update(self, project):
         """Test DuckLake accepts single UPDATE action"""

--- a/tests/functional/adapter/test_incremental.py
+++ b/tests/functional/adapter/test_incremental.py
@@ -570,6 +570,7 @@ class TestIncrementalMerge:
         assert alice[0] == 2  # version should be incremented
         assert alice[1] is not None  # updated_at should be set
 
+    @pytest.mark.skip_database_type("ducklake", reason="DuckLake does not support RETURNING")
     def test_merge_with_returning(self, project):
         """Test merge with returning columns"""
         run_dbt(["run", "--select", "merge_with_returning"], expect_pass=True)
@@ -580,6 +581,9 @@ class TestIncrementalMerge:
         result = project.run_sql(f"SELECT COUNT(*) as count FROM {relation}", fetch="one")
         assert result[0] == 4
 
+    @pytest.mark.skip_database_type(
+        "ducklake", reason="DuckLake supports only one MERGE update or delete action"
+    )
     def test_merge_custom_clauses(self, project):
         """Test merge with custom when_matched and when_not_matched clauses"""
         run_dbt(["run", "--select", "merge_custom_clauses"], expect_pass=True)

--- a/tests/functional/adapter/test_persist_docs.py
+++ b/tests/functional/adapter/test_persist_docs.py
@@ -7,19 +7,32 @@ from dbt.tests.adapter.persist_docs.test_persist_docs import (
 )
 from dbt.tests.util import run_dbt
 
+# DuckLake support is merged and will be available in a future release:
+# https://github.com/duckdb/ducklake/pull/1102
+
+@pytest.mark.skip_database_type(
+    "ducklake", reason="DuckLake does not support comments on view columns"
+)
 @pytest.mark.skip_profile("md")
 class TestPersistDocs(BasePersistDocs):
     pass
 
 
+@pytest.mark.skip_database_type(
+    "ducklake", reason="DuckLake does not support comments on view columns"
+)
 @pytest.mark.skip_profile("md")
 class TestPersistDocsColumnMissing(BasePersistDocsColumnMissing):
     pass
 
 
+@pytest.mark.skip_database_type(
+    "ducklake", reason="DuckLake does not support comments on view columns"
+)
 @pytest.mark.skip_profile("md")
 class TestPersistDocsCommentOnQuotedColumn(BasePersistDocsCommentOnQuotedColumn):
     pass
+
 
 @pytest.mark.requires_ducklake
 @pytest.mark.skip_profile("md", "buenavista")

--- a/tests/functional/adapter/test_simple_snapshot.py
+++ b/tests/functional/adapter/test_simple_snapshot.py
@@ -1,14 +1,6 @@
-import pytest
-
 from dbt.tests.adapter.simple_snapshot.test_snapshot import (
     BaseSnapshotCheck,
     BaseSimpleSnapshot,
-)
-
-
-pytestmark = pytest.mark.skip_database_type(
-    "ducklake",
-    reason="dbt snapshot execution still reaches a CASCADE drop that DuckLake rejects",
 )
 
 

--- a/tests/functional/adapter/test_simple_snapshot.py
+++ b/tests/functional/adapter/test_simple_snapshot.py
@@ -1,6 +1,14 @@
+import pytest
+
 from dbt.tests.adapter.simple_snapshot.test_snapshot import (
     BaseSnapshotCheck,
     BaseSimpleSnapshot,
+)
+
+
+pytestmark = pytest.mark.skip_database_type(
+    "ducklake",
+    reason="dbt snapshot execution still reaches a CASCADE drop that DuckLake rejects",
 )
 
 

--- a/tests/functional/plugins/motherduck/test_motherduck.py
+++ b/tests/functional/plugins/motherduck/test_motherduck.py
@@ -65,6 +65,7 @@ class TestMDPlugin:
                         "path": f"md:{test_database_name}",
                         "plugins": plugins,
                         "config_options": dbt_profile_target.get("config_options"),
+                        "is_ducklake": dbt_profile_target.get("is_ducklake"),
                     }
                 },
                 "target": "dev",

--- a/tests/unit/test_duckdb_adapter.py
+++ b/tests/unit/test_duckdb_adapter.py
@@ -350,4 +350,3 @@ class TestDuckDBAdapterIsDucklake(unittest.TestCase):
 
         result = adapter.is_ducklake(relation)
         self.assertTrue(result)
-

--- a/tox.ini
+++ b/tox.ini
@@ -78,3 +78,23 @@ commands =
 deps =
   -rdev-requirements.txt
   -e.
+
+[testenv:ducklake]
+description = adapter functional testing using a local DuckLake database
+skip_install = True
+passenv = *
+commands = {envpython} -m pytest --database-type=ducklake {posargs} tests/functional/adapter
+deps =
+  duckdb==1.5.4
+  -rdev-requirements.txt
+  -e.
+
+[testenv:md-ducklake]
+description = adapter functional testing using a managed DuckLake database in MotherDuck
+skip_install = True
+passenv = *
+commands = {envpython} -m pytest --profile=md --database-type=ducklake --maxfail=2 {posargs} tests/functional/plugins/motherduck tests/functional/adapter
+deps =
+  duckdb==1.5.4
+  -rdev-requirements.txt
+  -e.[md]

--- a/tox.ini
+++ b/tox.ini
@@ -85,7 +85,6 @@ skip_install = True
 passenv = *
 commands = {envpython} -m pytest --database-type=ducklake {posargs} tests/functional/adapter
 deps =
-  duckdb==1.5.4
   -rdev-requirements.txt
   -e.
 

--- a/tox.ini
+++ b/tox.ini
@@ -94,6 +94,6 @@ skip_install = True
 passenv = *
 commands = {envpython} -m pytest --profile=md --database-type=ducklake --maxfail=2 {posargs} tests/functional/plugins/motherduck tests/functional/adapter
 deps =
-  duckdb==1.5.4
+  duckdb==1.5.5
   -rdev-requirements.txt
   -e.[md]


### PR DESCRIPTION
This PR adds two testing targets: local DuckLake and managed DuckLake on MotherDuck.

Apart from the tests, there are two expected differences in user-facing behavior that this PR introduces:

- The tests flagged that dbt snapshots were not working as intended on DuckLake, since their temporary-relations were not special cased as the temporary relations of incremental models were. The adapter would attempt to pass an unsupported `drop cascade` on teardown. This PR aligns how temporary relations are handled in both cases. d62f6d2702ccb6256f2faa97c6da92763368f23a
- Some invalid ducklake configurations will nwo throw compile-time errors instead of runtime errors. bbe8805db5fa23db848f4f749ec9b0fa700c9e21
