### PR TITLE
run persist docs tests on MotherDuck

### DIFF
--- a/tests/functional/adapter/test_persist_docs.py
+++ b/tests/functional/adapter/test_persist_docs.py
@@ -13,7 +13,6 @@ from dbt.tests.util import run_dbt
 @pytest.mark.skip_database_type(
     "ducklake", reason="DuckLake does not support comments on view columns"
 )
-@pytest.mark.skip_profile("md")
 class TestPersistDocs(BasePersistDocs):
     pass
 
@@ -21,7 +20,6 @@ class TestPersistDocs(BasePersistDocs):
 @pytest.mark.skip_database_type(
     "ducklake", reason="DuckLake does not support comments on view columns"
 )
-@pytest.mark.skip_profile("md")
 class TestPersistDocsColumnMissing(BasePersistDocsColumnMissing):
     pass
 
@@ -29,13 +27,12 @@ class TestPersistDocsColumnMissing(BasePersistDocsColumnMissing):
 @pytest.mark.skip_database_type(
     "ducklake", reason="DuckLake does not support comments on view columns"
 )
-@pytest.mark.skip_profile("md")
 class TestPersistDocsCommentOnQuotedColumn(BasePersistDocsCommentOnQuotedColumn):
     pass
 
 
 @pytest.mark.requires_ducklake
-@pytest.mark.skip_profile("md", "buenavista")
+@pytest.mark.skip_profile("buenavista")
 class TestDuckLakePersistDocsTransactions:
     @pytest.fixture(scope="class")
     def ducklake_paths(self, tmp_path_factory):


### PR DESCRIPTION
Enables the standard persist_docs functional tests for the MotherDuck profile. The DuckLake-specific persist-docs transaction test remains skipped for MotherDuck.

Original PR: https://github.com/motherduckdb/dbt-duckdb/pull/38

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>