### PR TITLE
allow concurrent runs of motherduck tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -278,14 +278,6 @@ jobs:
     needs: [check-md-token]
     if: needs.check-md-token.outputs.exists == 'true'
 
-    # Tests share a single MotherDuck account/database (`md:test`), so concurrent
-    # runs across PRs/commits collide on catalog metadata and produce flaky
-    # failures. Serialize MotherDuck runs globally; queue rather than cancel so
-    # in-flight master runs aren't lost.
-    concurrency:
-      group: motherduck-functional-tests
-      cancel-in-progress: false
-
     runs-on: ubuntu-latest
 
     strategy:


### PR DESCRIPTION
Concurrent runs of motherduck test suite should be fine now after https://github.com/duckdb/dbt-duckdb/pull/777 which changed the test suite to create and use a new isolated database each run 