### PR TITLE
Remove unused logbook/pytest-logbook dev dependencies

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -31,8 +31,6 @@ pyiceberg
 pytest
 pytest-cov
 pytest-dotenv
-logbook<1.9  # pytest-logbook still imports logbook.compat
-pytest-logbook
 pytest-csv
 pytest-xdist
 pytest-mock


### PR DESCRIPTION
## Summary
- Removes `logbook<1.9` and `pytest-logbook` from `dev-requirements.txt`

## Why
Neither is referenced anywhere in the codebase (no `logbook` imports or `pytest-logbook`/`caplog`-style fixture usage found), so they're dead weight — dropping them also sheds the `logbook.compat` transitive dependency noted in the old comment.

## Testing
- `pytest tests/unit -q` — 113 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)