### PR TITLE
Update CI Python matrix for 3.14

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,7 +73,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.11', '3.12', '3.13', '3.14']
 
     env:
       TOXENV: "unit"
@@ -125,7 +125,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.11', '3.12', '3.13', '3.14']
 
     env:
       TOXENV: "functional"
@@ -173,7 +173,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.11', '3.12', '3.13', '3.14']
 
     env:
       TOXENV: "ducklake"
@@ -221,7 +221,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.11', '3.12', '3.13', '3.14']
 
     env:
       TOXENV: "filebased"
@@ -432,7 +432,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10']
+        python-version: ['3.11']
 
     env:
       TOXENV: "fsspec"
@@ -564,7 +564,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.11', '3.12', '3.13', '3.14']
 
     steps:
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.11', '3.12', '3.13']
+        python-version: ['3.11', '3.12', '3.13', '3.14']
 
     env:
       TOXENV: "nightly"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.11', '3.12', '3.13']
 
     env:
       TOXENV: "nightly"

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ classifier =
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3.13
+    Programming Language :: Python :: 3.14
 keywords =
     setup
     distutils

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 skipsdist = True
-envlist = py{310,311,312,313}
+envlist = py{311,312,313,314}
 
-[testenv:{unit,py310,py311,py312,py313,py}]
+[testenv:{unit,py311,py312,py313,py314,py}]
 description = unit testing
 skip_install = True
 passenv = *
@@ -11,7 +11,7 @@ deps =
   -rdev-requirements.txt
   -e.
 
-[testenv:{functional,py310,py311,py312,py313,py}]
+[testenv:{functional,py311,py312,py313,py314,py}]
 description = adapter functional testing
 skip_install = True
 passenv = *
@@ -20,7 +20,7 @@ deps =
   -rdev-requirements.txt
   -e.
 
-[testenv:{filebased,py310,py311,py312,py313,py}]
+[testenv:{filebased,py311,py312,py313,py314,py}]
 description = adapter functional testing using file-based DBs
 skip_install = True
 passenv = *
@@ -29,7 +29,7 @@ deps =
   -rdev-requirements.txt
   -e.
 
-[testenv:{buenavista,py310}]
+[testenv:{buenavista,py311}]
 description = adapter functional testing using a Buena Vista server
 skip_install = True
 passenv = *
@@ -48,7 +48,7 @@ deps =
   -rdev-requirements.txt
   -e.[md]
 
-[testenv:{fsspec,py310,py311,py312,py313,py}]
+[testenv:{fsspec,py311,py312,py313,py314,py}]
 description = adapter fsspec testing
 skip_install = True
 passenv = *
@@ -57,7 +57,7 @@ deps =
   -rdev-requirements.txt
   -e.
 
-[testenv:{plugins,py310,py311,py312,py313,py}]
+[testenv:{plugins,py311,py312,py313,py314,py}]
 description = adapter plugin testing
 skip_install = True
 passenv = *
@@ -67,7 +67,7 @@ deps =
   -rdev-requirements.txt
   -e.
 
-[testenv:{nightly,py310,py311,py312,py313,py}]
+[testenv:{nightly,py311,py312,py313,py314,py}]
 description = duckdb nightly release testing
 skip_install = True
 passenv = *


### PR DESCRIPTION
## Summary

- Replace Python 3.10 with Python 3.14 in the general unit, functional, DuckLake, file-based, and package-verification CI matrices.
- Run the fsspec and Buena Vista jobs on Python 3.11.
- Add Python 3.14 to the tox matrix and package classifiers.
- Retain `python_requires >=3.10` and the Python 3.10 classifier for now, so this changes CI coverage without prematurely dropping declared package support.

## Motivation

Python 3.10 is in security-only maintenance and reaches end of life in October 2026. Python 3.14 is now the current bugfix release, and both DuckDB and dbt Core 1.12 support it. The CI should exercise the current compatibility range while preserving the existing public support floor.

## Validation

- `git diff --check` passed.
- `tox c -e unit,py314,buenavista,fsspec,nightly` passed.
- `actionlint` passed for `.github/workflows/main.yml` and `.github/workflows/nightly.yml`.