### PR TITLE
Test PyArrow 25.0.1 with MotherDuck

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -14,7 +14,7 @@ dbt-tests-adapter==1.20.0
 boto3
 mypy-boto3-glue
 pandas
-pyarrow==24.0.0
+pyarrow==25.0.1
 buenavista==0.5.0
 bumpversion
 flaky


### PR DESCRIPTION
Bumps the development PyArrow pin from 24.0.0 to 25.0.1.

This maintainer-owned draft PR exists to exercise the token-backed Linux MotherDuck test jobs, following the PyArrow 25.0.0 rollback for MotherDuck integration-test segfaults.

No production package dependency changes.