### PR TITLE
Declare typed DuckDB table lifecycle planning

### DIFF
--- a/dbt/adapters/duckdb/impl.py
+++ b/dbt/adapters/duckdb/impl.py
@@ -2,6 +2,7 @@ import os
 import traceback
 from collections import defaultdict
 from dataclasses import dataclass
+from dataclasses import replace
 from datetime import datetime
 from functools import cached_property
 from typing import Any
@@ -45,6 +46,11 @@ from dbt.adapters.duckdb.utils import TargetLocation
 from dbt.adapters.events.logging import AdapterLogger
 from dbt.adapters.exceptions import IndexConfigError
 from dbt.adapters.exceptions import IndexConfigNotDictError
+from dbt.adapters.planning import ExistingIndexStrategy
+from dbt.adapters.planning import PlanProvenance
+from dbt.adapters.planning import TableDocumentationStrategy
+from dbt.adapters.planning import TableIndexStrategy
+from dbt.adapters.planning import TableLifecyclePlan
 from dbt.adapters.sql import SQLAdapter
 
 
@@ -119,6 +125,49 @@ class DuckDBAdapter(SQLAdapter):
     # can be overridden via the model config metadata
     _temp_schema_name = DEFAULT_TEMP_SCHEMA_NAME
     _temp_schema_model_uuid: dict[str, str] = defaultdict(lambda: str(uuid4()).split("-")[-1])
+
+    @available.parse_none
+    def plan_table_materialization(
+        self, materialization_macro_id: str, language: str, model: Optional[Any] = None
+    ) -> Optional[TableLifecyclePlan]:
+        if (
+            language != "sql"
+            or materialization_macro_id
+            != "macro.dbt_duckdb.materialization_table_duckdb"
+        ):
+            return super().plan_table_materialization(materialization_macro_id, language, model)
+        config = getattr(model, "config", None)
+        if config is not None and any(
+            config.get(name) is not None
+            for name in ("partitioned_by", "partition_by", "sorted_by", "sort_by")
+        ):
+            return None
+        return TableLifecyclePlan.stage_and_swap(
+            indexes=TableIndexStrategy.AFTER_SWAP,
+            existing_indexes=ExistingIndexStrategy.DROP_BEFORE_SWAP,
+            provenance=(
+                PlanProvenance(
+                    rule="materialization.table.stage_and_swap",
+                    detail="DuckDB applies indexes to the target relation after swapping",
+                ),
+            ),
+        )
+
+    @available
+    def resolve_table_lifecycle_plan(
+        self,
+        plan: TableLifecyclePlan,
+        model: Any,
+        target_relation: BaseRelation,
+        config: Any,
+    ) -> TableLifecyclePlan:
+        if not self.is_ducklake(target_relation):
+            return plan
+
+        return replace(
+            plan,
+            documentation=TableDocumentationStrategy.AFTER_COMMIT,
+        )
 
     @classmethod
     def date_function(cls) -> str:

--- a/tests/unit/test_materialization_planning.py
+++ b/tests/unit/test_materialization_planning.py
@@ -1,0 +1,84 @@
+from dbt.adapters.duckdb.impl import DuckDBAdapter
+from dbt.adapters.duckdb.relation import DuckDBRelation
+from dbt.adapters.planning import (
+    ExistingIndexStrategy,
+    TableDocumentationStrategy,
+    TableIndexStrategy,
+    TableReplacementStrategy,
+)
+
+
+def _adapter() -> DuckDBAdapter:
+    return object.__new__(DuckDBAdapter)
+
+
+def test_duckdb_sql_table_resolves_stage_and_swap_index_policies() -> None:
+    plan = DuckDBAdapter.plan_table_materialization(
+        _adapter(),
+        "macro.dbt_duckdb.materialization_table_duckdb",
+        "sql",
+    )
+
+    assert plan.replacement == TableReplacementStrategy.STAGE_AND_SWAP
+    assert plan.indexes == TableIndexStrategy.AFTER_SWAP
+    assert plan.existing_indexes == ExistingIndexStrategy.DROP_BEFORE_SWAP
+
+
+def test_ducklake_runtime_facts_refine_docs_and_statement_boundaries() -> None:
+    adapter = _adapter()
+    adapter.is_ducklake = lambda relation: True
+    relation = DuckDBRelation.create(
+        database="lake",
+        schema="mart",
+        identifier="orders",
+        type="table",
+    )
+    plan = DuckDBAdapter.plan_table_materialization(
+        adapter,
+        "macro.dbt_duckdb.materialization_table_duckdb",
+        "sql",
+    )
+
+    resolved = DuckDBAdapter.resolve_table_lifecycle_plan(
+        adapter,
+        plan,
+        object(),
+        relation,
+        {},
+    )
+
+    assert resolved.documentation == TableDocumentationStrategy.AFTER_COMMIT
+
+
+def test_storage_configured_table_stays_on_jinja_compatibility_path() -> None:
+    model = type("Model", (), {"config": {"partitioned_by": ["ordered_at"]}})()
+
+    plan = DuckDBAdapter.plan_table_materialization(
+        _adapter(),
+        "macro.dbt_duckdb.materialization_table_duckdb",
+        "sql",
+        model,
+    )
+
+    assert plan is None
+
+
+def test_plain_duckdb_keeps_base_runtime_policies() -> None:
+    adapter = _adapter()
+    adapter.is_ducklake = lambda relation: False
+    relation = DuckDBRelation.create(identifier="orders", type="table")
+    plan = DuckDBAdapter.plan_table_materialization(
+        adapter,
+        "macro.dbt_duckdb.materialization_table_duckdb",
+        "sql",
+    )
+
+    resolved = DuckDBAdapter.resolve_table_lifecycle_plan(
+        adapter,
+        plan,
+        object(),
+        relation,
+        {},
+    )
+
+    assert resolved is plan


### PR DESCRIPTION
## Summary
- opt ordinary SQL table models into typed stage/swap lifecycle planning
- declare target-after-swap index creation and pre-swap index cleanup
- refine DuckLake documentation to the post-commit boundary
- keep Python and partition/sort-configured models on the existing Jinja compatibility path

## Dependency
Draft depends on the companion dbt-adapters and dbt-core lifecycle-plan PRs.

## Validation
- 4 focused lifecycle planning tests passed
- scoped MyPy passed