### PR TITLE
Fix model-level foreign key rendering

### DIFF
--- a/dbt/adapters/duckdb/impl.py
+++ b/dbt/adapters/duckdb/impl.py
@@ -12,6 +12,7 @@ from uuid import uuid4
 
 from dbt_common.contracts.constraints import ColumnLevelConstraint
 from dbt_common.contracts.constraints import ConstraintType
+from dbt_common.contracts.constraints import ModelLevelConstraint
 from dbt_common.dataclass_schema import dbtClassMixin
 from dbt_common.dataclass_schema import ValidationError
 from dbt_common.exceptions import DbtDatabaseError
@@ -396,18 +397,37 @@ class DuckDBAdapter(SQLAdapter):
         rendering."""
         if constraint.type == ConstraintType.foreign_key:
             if constraint.to and constraint.to_columns:
-                # TODO: this is a hack to get around a limitation in DuckDB around setting FKs
-                # across databases.
-                pieces = constraint.to.split(".")
-                if len(pieces) > 2:
-                    constraint_to = ".".join(pieces[1:])
-                else:
-                    constraint_to = constraint.to
+                constraint_to = cls._constraint_target_without_database(constraint.to)
                 return f"references {constraint_to} ({', '.join(constraint.to_columns)})"
             else:
                 return f"references {constraint.expression}"
         else:
             return super().render_column_constraint(constraint)
+
+    @classmethod
+    def render_model_constraint(cls, constraint: ModelLevelConstraint) -> Optional[str]:
+        if (
+            constraint.type == ConstraintType.foreign_key
+            and constraint.to
+            and constraint.to_columns
+        ):
+            constraint_prefix = f"constraint {constraint.name} " if constraint.name else ""
+            column_list = ", ".join(constraint.columns)
+            constraint_to = cls._constraint_target_without_database(constraint.to)
+            return (
+                f"{constraint_prefix}foreign key ({column_list}) references "
+                f"{constraint_to} ({', '.join(constraint.to_columns)})"
+            )
+        return super().render_model_constraint(constraint)
+
+    @staticmethod
+    def _constraint_target_without_database(constraint_to: str) -> str:
+        # DuckDB does not accept a catalog-qualified foreign key target, even when
+        # the target is in the current catalog.
+        pieces = constraint_to.split(".")
+        if len(pieces) > 2:
+            return ".".join(pieces[1:])
+        return constraint_to
 
     def _clean_up_temp_relation_for_incremental(self, config):
         if self.is_motherduck() and hasattr(config, "model"):

--- a/tests/functional/adapter/test_constraints.py
+++ b/tests/functional/adapter/test_constraints.py
@@ -10,6 +10,7 @@ from dbt.tests.adapter.constraints.test_constraints import (
     BaseIncrementalConstraintsRollback,
     BaseModelConstraintsRuntimeEnforcement,
 )
+from dbt.tests.util import run_dbt
 
 
 pytestmark = pytest.mark.skip_database_type(
@@ -103,3 +104,48 @@ class TestModelConstraintsRuntimeEnforcement(
     @pytest.fixture(scope="class")
     def expected_error_messages(self):
         return ["NOT NULL constraint failed"]
+
+
+@pytest.mark.skip_profile("md", "buenavista")
+class TestCompositeModelLevelForeignKey:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "parent.sql": "select 1 as id, 'parent' as type",
+            "child.sql": "select 1 as parent_id, 'parent' as parent_type",
+            "schema.yml": """
+version: 2
+models:
+  - name: parent
+    config:
+      contract:
+        enforced: true
+    constraints:
+      - type: primary_key
+        columns: [id, type]
+    columns:
+      - name: id
+        data_type: integer
+      - name: type
+        data_type: varchar
+  - name: child
+    config:
+      contract:
+        enforced: true
+    constraints:
+      - type: foreign_key
+        columns: [parent_id, parent_type]
+        to: ref('parent')
+        to_columns: [id, type]
+    columns:
+      - name: parent_id
+        data_type: integer
+      - name: parent_type
+        data_type: varchar
+""",
+        }
+
+    def test_composite_model_level_foreign_key(self, project):
+        results = run_dbt(["run"])
+
+        assert len(results) == 2

--- a/tests/unit/test_duckdb_adapter.py
+++ b/tests/unit/test_duckdb_adapter.py
@@ -2,6 +2,9 @@ import unittest
 from argparse import Namespace
 from unittest import mock
 
+from dbt_common.contracts.constraints import ColumnLevelConstraint
+from dbt_common.contracts.constraints import ConstraintType
+from dbt_common.contracts.constraints import ModelLevelConstraint
 from dbt.flags import set_from_args
 from dbt.adapters.duckdb import DuckDBAdapter
 from dbt.adapters.duckdb.connections import DuckDBConnectionManager
@@ -75,6 +78,34 @@ class TestDuckDBAdapter(unittest.TestCase):
             self.assertIsNone(self.adapter.expand_column_types(mock.MagicMock(), mock.MagicMock()))
             get_cols.assert_not_called()
             alter.assert_not_called()
+
+    def test_render_column_foreign_key_omits_database(self):
+        constraint = ColumnLevelConstraint(
+            type=ConstraintType.foreign_key,
+            to='"database"."schema"."parent"',
+            to_columns=["id"],
+        )
+
+        rendered = self.adapter.render_column_constraint(constraint)
+
+        self.assertEqual(rendered, 'references "schema"."parent" (id)')
+
+    def test_render_model_foreign_key_omits_database(self):
+        constraint = ModelLevelConstraint(
+            type=ConstraintType.foreign_key,
+            name="child_parent_fk",
+            columns=["parent_id", "parent_type"],
+            to='"database"."schema"."parent"',
+            to_columns=["id", "type"],
+        )
+
+        rendered = self.adapter.render_model_constraint(constraint)
+
+        self.assertEqual(
+            rendered,
+            'constraint child_parent_fk foreign key (parent_id, parent_type) '
+            'references "schema"."parent" (id, type)',
+        )
 
 
 class TestDuckDBAdapterWithSecrets(unittest.TestCase):


### PR DESCRIPTION
## Summary

- omit the database/catalog qualifier when rendering structured model-level foreign keys
- share the DuckDB-specific target normalization with column-level foreign keys
- add unit and functional coverage for composite foreign keys

Fixes #836.

## Testing

- `uv run pytest -q tests/unit` (115 passed)
- `uv run pytest -q tests/functional/adapter/test_constraints.py` (18 passed)
- `uv run pre-commit run --files dbt/adapters/duckdb/impl.py tests/unit/test_duckdb_adapter.py tests/functional/adapter/test_constraints.py`