### PR TITLE
Support motherduck_token as a top-level profile property

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,19 @@ purpose, column meaning, and expected grain before they generate queries.
 As of `dbt-duckdb` 1.5.2, you can connect to a DuckDB instance running on [MotherDuck](http://www.motherduck.com) by setting your `path` to use a [md:<database> connection string](https://motherduck.com/docs/getting-started/connect-query-from-python/installation-authentication), just as you would with the DuckDB CLI
 or the Python API.
 
+You can pass your [MotherDuck token](https://motherduck.com/docs/key-tasks/authenticating-and-connecting-to-motherduck/authenticating-to-motherduck/) via the `motherduck_token` property in your profile
+(it may also be set in the `settings` dictionary, as a `motherduck_token` query parameter on the `path`, or via the `motherduck_token` environment variable):
+
+```yaml
+default:
+  outputs:
+    dev:
+      type: duckdb
+      path: "md:my_db"
+      motherduck_token: "{{ env_var('MOTHERDUCK_TOKEN') }}"
+  target: dev
+```
+
 MotherDuck databases generally work the same way as local DuckDB databases from the perspective of dbt, but
 there are a [few differences to be aware of](https://motherduck.com/docs/architecture-and-capabilities#considerations-and-limitations):
 1. MotherDuck is compatible with client DuckDB versions 0.10.2 and newer.

--- a/dbt/adapters/duckdb/credentials.py
+++ b/dbt/adapters/duckdb/credentials.py
@@ -240,8 +240,22 @@ class DuckDBCredentials(Credentials):
     # which is the case in fully managed ducklake in MotherDuck.
     is_ducklake: Optional[bool] = None
 
+    # The access token to use when connecting to MotherDuck (i.e., when the
+    # path or an attached database uses the md: scheme); equivalent to
+    # setting motherduck_token in the settings dictionary.
+    motherduck_token: Optional[str] = None
+
     def __post_init__(self):
         self.settings = self.settings or {}
+
+        if self.motherduck_token:
+            existing_token = self.settings.get("motherduck_token")
+            if existing_token is not None and existing_token != self.motherduck_token:
+                raise DbtRuntimeError(
+                    "Conflicting values for motherduck_token found in the profile; "
+                    "please set it in only one place"
+                )
+            self.settings["motherduck_token"] = self.motherduck_token
         self.secrets = self.secrets or []
         self._secrets = []
 

--- a/dbt/adapters/duckdb/plugins/motherduck.py
+++ b/dbt/adapters/duckdb/plugins/motherduck.py
@@ -87,4 +87,10 @@ class Plugin(BasePlugin):
         # If a user specified MotherDuck config options via the plugin config,
         # pass it to the config kwarg in duckdb.connect.
         if not creds.is_motherduck_attach:
-            config.update(self.get_md_config_settings(self._config))
+            md_config = self.get_md_config_settings(self._config)
+            config.update(md_config)
+            # MotherDuck config options can only be set at connection init,
+            # so remove them from settings to prevent SET statements on cursors
+            for key in md_config:
+                if creds.settings is not None:
+                    creds.settings.pop(key, None)

--- a/tests/functional/plugins/motherduck/test_motherduck.py
+++ b/tests/functional/plugins/motherduck/test_motherduck.py
@@ -125,6 +125,26 @@ class TestMDPlugin:
         assert res == (70,)
 
 
+@pytest.mark.skip_profile("buenavista", "file", "memory")
+class TestMDPluginWithTopLevelToken(TestMDPlugin):
+    @pytest.fixture(scope="class")
+    def profiles_config_update(self, dbt_profile_target, test_database_name):
+        return {
+            "test": {
+                "outputs": {
+                    "dev": {
+                        "type": "duckdb",
+                        "path": f"md:{test_database_name}",
+                        "motherduck_token": dbt_profile_target.get("token"),
+                        "config_options": dbt_profile_target.get("config_options"),
+                        "is_ducklake": dbt_profile_target.get("is_ducklake"),
+                    }
+                },
+                "target": "dev",
+            }
+        }
+
+
 @pytest.fixture
 def mock_plugin_config():
     return {"token": "quack"}

--- a/tests/functional/plugins/motherduck/test_motherduck_attach.py
+++ b/tests/functional/plugins/motherduck/test_motherduck_attach.py
@@ -124,6 +124,30 @@ class TestMDPluginAttachWithSettings(TestMDPluginAttach):
 
 
 @pytest.mark.skip_profile("buenavista", "file", "memory")
+class TestMDPluginAttachWithTopLevelToken(TestMDPluginAttach):
+    @pytest.fixture(scope="class")
+    def profiles_config_update(self, dbt_profile_target, test_database_name):
+        return {
+            "test": {
+                "outputs": {
+                    "dev": {
+                        "type": "duckdb",
+                        "path": ":memory:",
+                        "motherduck_token": dbt_profile_target.get("token"),
+                        "attach": [
+                            {
+                                "path": f"md:{test_database_name}",
+                                "type": "motherduck"
+                            }
+                        ]
+                    }
+                },
+                "target": "dev",
+            }
+        }
+
+
+@pytest.mark.skip_profile("buenavista", "file", "memory")
 class TestMDPluginAttachWithTokenInPath(TestMDPluginAttach):
     @pytest.fixture(scope="class")
     def profiles_config_update(self, dbt_profile_target, test_database_name):

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -455,3 +455,38 @@ def test_add_secret_with_list():
     allowed_hosts array ['host1', 'host2', 'host3']
 )"""
     assert sql == expected
+
+
+def test_motherduck_token_top_level():
+    creds = DuckDBCredentials(path="md:my_db", motherduck_token="quack")
+    assert creds.settings["motherduck_token"] == "quack"
+    # the auto-added motherduck plugin moves the token from the settings
+    # into the duckdb.connect config for non-attach connections
+    assert "motherduck" in [p.module for p in creds.plugins]
+    from dbt.adapters.duckdb.plugins import BasePlugin
+
+    plugin = BasePlugin.create("motherduck", credentials=creds)
+    config = {}
+    plugin.update_connection_config(creds, config)
+    assert config["motherduck_token"] == "quack"
+    assert "motherduck_token" not in creds.settings
+
+
+def test_motherduck_token_top_level_matching_settings():
+    creds = DuckDBCredentials(
+        path="md:my_db",
+        motherduck_token="quack",
+        settings={"motherduck_token": "quack"},
+    )
+    assert creds.settings["motherduck_token"] == "quack"
+
+
+def test_motherduck_token_conflict():
+    from dbt_common.exceptions import DbtRuntimeError
+
+    with pytest.raises(DbtRuntimeError):
+        DuckDBCredentials(
+            path="md:my_db",
+            motherduck_token="quack",
+            settings={"motherduck_token": "honk"},
+        )


### PR DESCRIPTION
Add a top-level `motherduck_token` credential into settings in `__post_init__` and crash on a conflict with the old settings-setup. Also drop MotherDuck config keys from the settings after moving them into the connect config: `SET motherduck_token='...'` on a live connection fails with 'can only be set during initialization' when cursors re-apply settings. 