### PR TITLE
Fix sql_header on models with enforced contracts

### DIFF
--- a/dbt/include/duckdb/macros/adapters.sql
+++ b/dbt/include/duckdb/macros/adapters.sql
@@ -251,6 +251,20 @@ def materialize(df, con):
   );
 {% endmacro %}
 
+{% macro duckdb__get_empty_subquery_sql(select_sql, select_sql_header=none) %}
+    {#- get_column_schema_from_query wraps this in DESCRIBE (...), which cannot parse
+        an inlined sql_header (issue #515), so run the header separately to keep its
+        session effects visible to the describe -#}
+    {%- if select_sql_header is not none -%}
+      {%- do run_query(select_sql_header) -%}
+    {%- endif -%}
+    select * from (
+        {{ select_sql }}
+    ) as __dbt_sbq
+    where false
+    limit 0
+{% endmacro %}
+
 {% macro duckdb__get_columns_in_relation(relation) -%}
   {# DESCRIBE avoids the global information_schema.columns scan, which forces a full
      catalog load on attached catalogs like DuckLake (issue #762). DuckDB's column_type

--- a/tests/functional/adapter/test_sql_header.py
+++ b/tests/functional/adapter/test_sql_header.py
@@ -1,0 +1,44 @@
+import pytest
+
+from dbt.tests.util import run_dbt
+
+model_sql = """
+{{ config(materialized='table') }}
+{% call set_sql_header(config) %}
+create or replace temp macro magic() as 42;
+{% endcall %}
+select magic() as answer
+"""
+
+contract_schema_yml = """
+models:
+  - name: header_model
+    config:
+      contract:
+        enforced: true
+    columns:
+      - name: answer
+        data_type: integer
+"""
+
+
+class BaseSqlHeader:
+    def test_sql_header(self, project):
+        run_dbt(["run"])
+        rows = project.run_sql("select answer from {schema}.header_model", fetch="one")
+        assert rows[0] == 42
+
+
+class TestSqlHeader(BaseSqlHeader):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"header_model.sql": model_sql}
+
+
+class TestSqlHeaderWithContract(BaseSqlHeader):
+    """sql_header used to break enforced contracts: the header was inlined into the
+    DESCRIBE the schema check runs (issue #515)."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"header_model.sql": model_sql, "schema.yml": contract_schema_yml}


### PR DESCRIPTION
The contract schema check renders get_empty_subquery_sql and wraps the result in DESCRIBE (...). The default macro inlines the sql_header into that string, which DuckDB cannot parse (DESCRIBE takes a single query, not a statement list), so any model combining sql_header with an enforced contract fails with a parser error.

Solution: override duckdb__get_empty_subquery_sql to execute the header as its own statement via run_query instead of concatenating it. The header runs on the same connection, so session effects (SET, temp macros) the model depends on stay visible to the describe.

Fixes #515.