### PR TITLE
Add ducklake plugin to register external files in a DuckLake catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,6 +494,39 @@ relative to the current working directory, but you can change the default direct
 
 Unfortunately incremental materialization strategies are not yet supported for `external` models.
 
+##### Registering external files in a DuckLake catalog
+
+The built-in `ducklake` plugin registers the parquet file written by an `external` model into an attached
+[DuckLake](https://ducklake.select/) catalog via
+[`ducklake_add_data_files`](https://ducklake.select/docs/stable/duckdb/maintenance/add_files) — the file is added to the
+lake's metadata without being copied. The lake table is created from the parquet schema if it does not exist yet.
+
+```yaml
+default:
+  outputs:
+    dev:
+      type: duckdb
+      path: /tmp/dbt.duckdb
+      attach:
+        - path: "ducklake:metadata.ducklake"
+          alias: my_lake
+      plugins:
+        - module: ducklake
+          config:
+            database: my_lake
+```
+
+```
+{{ config(materialized='external', plugin='ducklake') }}
+SELECT ...
+```
+
+The target DuckLake database is set via the `database` plugin config or per-model with `ducklake_database`. Optional
+model (or plugin) configs: `ducklake_schema` (default `main`), `ducklake_table` (default: the model name), and the
+`ignore_extra_columns`/`allow_missing_columns` options of `ducklake_add_data_files`. Note that the file must be
+readable where the catalog runs its queries: registering files from a local disk into a remote (e.g.
+MotherDuck-managed) DuckLake catalog will not work — write the model to object storage the catalog can read instead.
+
 
 #### Incremental Strategy Configuration
 

--- a/dbt/adapters/duckdb/plugins/ducklake.py
+++ b/dbt/adapters/duckdb/plugins/ducklake.py
@@ -1,0 +1,65 @@
+from typing import Any
+from typing import Dict
+
+from duckdb import DuckDBPyConnection
+
+from . import BasePlugin
+from ..utils import escape_sql_string
+from ..utils import TargetConfig
+
+# ducklake_add_data_files options that may be set in the model or plugin config
+PASSTHROUGH_OPTIONS = ["ignore_extra_columns", "allow_missing_columns"]
+
+
+def _ident(name: str) -> str:
+    return '"' + name.replace('"', '""') + '"'
+
+
+class Plugin(BasePlugin):
+    """Registers the parquet file written by an `external` materialization into an
+    attached DuckLake catalog via ducklake_add_data_files, instead of copying the data.
+
+    The target DuckLake database is set by the `database` plugin config or the
+    `ducklake_database` model config; the table defaults to the model name and is
+    created from the parquet schema if it does not exist yet.
+    """
+
+    def initialize(self, plugin_config: Dict[str, Any]):
+        self._config = plugin_config
+
+    def configure_connection(self, conn: DuckDBPyConnection):
+        self._conn = conn
+
+    def store(self, target_config: TargetConfig):
+        assert target_config.location is not None
+        assert target_config.relation.identifier is not None
+        database = target_config.config.get("ducklake_database") or self._config.get("database")
+        if not database:
+            raise ValueError(
+                "The ducklake plugin requires the DuckLake database alias, set via the "
+                "'database' plugin config or the 'ducklake_database' model config"
+            )
+        schema = target_config.config.get("ducklake_schema") or self._config.get("schema", "main")
+        table = target_config.config.get("ducklake_table") or target_config.relation.identifier
+        path = target_config.location.path
+
+        options = ""
+        for option in PASSTHROUGH_OPTIONS:
+            value = target_config.config.get(option, self._config.get(option))
+            if value is not None:
+                options += f", {option} => {'true' if value else 'false'}"
+
+        qualified = f"{_ident(database)}.{_ident(schema)}.{_ident(table)}"
+        cursor = self._conn.cursor()
+        try:
+            cursor.execute(
+                f"CREATE TABLE IF NOT EXISTS {qualified} AS "
+                f"SELECT * FROM read_parquet('{escape_sql_string(path)}') LIMIT 0"
+            )
+            cursor.execute(
+                f"CALL ducklake_add_data_files('{escape_sql_string(database)}', "
+                f"'{escape_sql_string(table)}', '{escape_sql_string(path)}', "
+                f"schema => '{escape_sql_string(schema)}'{options})"
+            )
+        finally:
+            cursor.close()

--- a/tests/functional/plugins/test_ducklake.py
+++ b/tests/functional/plugins/test_ducklake.py
@@ -1,0 +1,51 @@
+import pytest
+
+from dbt.tests.util import run_dbt
+
+events_sql = """
+{{ config(materialized='external', plugin='ducklake') }}
+select 1 as id, 'a' as val union all select 2 as id, 'b' as val
+"""
+
+overrides_sql = """
+{{ config(materialized='external', plugin='ducklake', ducklake_schema='raw', ducklake_table='renamed') }}
+select 3 as id
+"""
+
+
+@pytest.mark.skip_profile("buenavista", "md", "nightly")
+class TestDuckLakePlugin:
+    @pytest.fixture(scope="class")
+    def lake_dirs(self, tmp_path_factory):
+        base = tmp_path_factory.mktemp("ducklake_plugin")
+        (base / "external").mkdir()
+        return str(base / "lake.ducklake"), str(base / "external")
+
+    @pytest.fixture(scope="class")
+    def dbt_profile_target(self, dbt_profile_target, lake_dirs):
+        catalog, external_root = lake_dirs
+        dbt_profile_target["extensions"] = ["ducklake"]
+        dbt_profile_target["external_root"] = external_root
+        dbt_profile_target["attach"] = [{"path": f"ducklake:{catalog}", "alias": "lake"}]
+        dbt_profile_target["plugins"] = [{"module": "ducklake", "config": {"database": "lake"}}]
+        return dbt_profile_target
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"events.sql": events_sql, "overrides.sql": overrides_sql}
+
+    def test_register_parquet_in_ducklake(self, project):
+        project.run_sql("create schema lake.raw")
+        results = run_dbt()
+        assert len(results) == 2
+
+        rows = project.run_sql("select count(*), min(id), max(id) from lake.events", fetch="one")
+        assert rows == (2, 1, 2)
+        # the parquet file is registered, not copied
+        files = project.run_sql(
+            "select count(*) from ducklake_list_files('lake', 'events')", fetch="one"
+        )
+        assert files[0] == 1
+
+        rows = project.run_sql("select id from lake.raw.renamed", fetch="one")
+        assert rows == (3,)


### PR DESCRIPTION
Adds a built-in plugin that registers the parquet file written by an external materialization into an attached DuckLake catalog via `ducklake_add_data_files` instead of copying the data. The lake table is created from the parquet schema if it does not exist yet. Configured with the lake's attach alias ('database' plugin config or 'ducklake_database' model config), optional 'ducklake_schema', 'ducklake_table', and pass-through of the `ignore_extra_columns` / `allow_missing_columns` options.